### PR TITLE
receive Frame Sync sync_word using variable

### DIFF
--- a/examples/tx_rx_functionnality_check.grc
+++ b/examples/tx_rx_functionnality_check.grc
@@ -348,7 +348,7 @@ blocks:
     os_factor: int(samp_rate/bw)
     sf: sf
     show_log_port: 'False'
-    sync_word: '18'
+    sync_word: sync_word
   states:
     bus_sink: false
     bus_source: false


### PR DESCRIPTION
In the tx_rx_functionnality_check.grc is a sync_word variable. That is used in the TX path, but not in the RX path. This makes Frame Sync use the variable.