### PR TITLE
Fix alignment of tags after crc_verif block

### DIFF
--- a/lib/crc_verif_impl.h
+++ b/lib/crc_verif_impl.h
@@ -20,7 +20,7 @@ namespace gr {
         std::vector<uint8_t> in_buff;///< input buffer containing the data bytes and CRC if any
         bool print_rx_msg;  ///< print received message in terminal or not
         bool output_crc_check; ///< output the result of the payload CRC check
-
+        tag_t curent_tag; ///< the most recent tag for the packet we are currently processing
         
 
         uint32_t cnt=0;///< count the number of frame


### PR DESCRIPTION
The CRC verify block consumes N+2 bytes and produces N bytes, but does not adjust the absolute offset of the `frame_info` tag. As a result, the tag offset does not track with the read offset after the first packet.

Here's an example of the tag offset shifting back 2 bytes per RX packet:
```
==== BEFORE CRC VERIFY BLOCK ====
Tag Key: frame_info
Tag Value: ((err . 0) (ldro_mode . 1) (crc . 1) (pay_len . 15) (cr . 4))
Tag Offset: 0
Read offset: 0
Payload Length: 15
Buffer Length: 2
==== AFTER CRC VERIFY BLOCK ====
Tag Key: frame_info
Tag Value: ((err . 0) (ldro_mode . 1) (crc . 1) (pay_len . 15) (cr . 4))
Tag Offset: 0
Read offset: 0
Payload Length: 15
Buffer Length: 15
[ -1 -35   0   0  72 101 108 108 111  32  87 111 114 108 100]

==== BEFORE CRC VERIFY BLOCK ====
Tag Key: frame_info
Tag Value: ((err . 0) (ldro_mode . 1) (crc . 1) (pay_len . 54) (cr . 4))
Tag Offset: 17
Read offset: 17
Payload Length: 54
Buffer Length: 2
==== AFTER CRC VERIFY BLOCK ====
Tag Key: frame_info
Tag Value: ((err . 0) (ldro_mode . 1) (crc . 1) (pay_len . 54) (cr . 4))
Tag Offset: 17
Read offset: 15
Payload Length: 54
Buffer Length: 54
[   0    0   75   78   54   72   67   67   31    6    1    0    0    0
 -100  -93  -62  118    0    0    5  -16   -1  125   32    0    1   32
    0 -112  116   16 -126  112  122   37  123   31  124  -63  123  123
   57  -75 -110   90    6    0    0  -24   75   72]

==== BEFORE CRC VERIFY BLOCK ====
Tag Key: frame_info
Tag Value: ((err . 0) (ldro_mode . 1) (crc . 1) (pay_len . 15) (cr . 4))
Tag Offset: 73
Read offset: 73
Payload Length: 15
Buffer Length: 2
==== AFTER CRC VERIFY BLOCK ====
Tag Key: frame_info
Tag Value: ((err . 0) (ldro_mode . 1) (crc . 1) (pay_len . 15) (cr . 4))
Tag Offset: 73
Read offset: 69
Payload Length: 15
Buffer Length: 15
[ 72 101 108 108 111  32  87 111 114 108 100]
```

The attached change adjusts crc_verif to include the crc bytes in the produced byte stream. This prevents the offset shifting issue.

An alternative approach would be to adjust crc_verif to shift the tags backwards after removing the CRC bytes. Let me know if you think that would be preferable.