### PR TITLE
Added cpp code generation capability to Rx blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,39 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) 
 
 
+# Branch Info
+We will implement c++ capability to all blocks in this repo.
+This means adding the following lines to each of the block's .yml: 
+
+* ```
+  flags: [ python, cpp ]
+  ```
+* ``` 
+  cpp_templates: 
+  includes: ['#include <gnuradio/lora_sdr/<BLOCK_NAME>.h>'] 
+  declarations: 'lora_sdr::<BLOCK_NAME>::sptr ${id};' 
+  make: 'this->${id} = lora_sdr::<BLOCK_NAME>::make(<PARAMS>);'
+  packages: ['gnuradio-lora_sdr']
+  link: ['gnuradio::gnuradio-lora_sdr']
+  translations:
+     'False': 'false'
+     'True': 'true'
+     \[: '{'
+     \]: '}'
+  ```
+
+notice the <BLOCK_NAME> and <PARAMS> tag.
+for example you can look at `/grc/lora_sdr_frame_sync.block.yml` where it is already implemented
+
+Reciever Blocks to do:
+- [ ] lora_sdr_fft_demod.block.yml
+- [ ] lora_sdr_gray_mapping.block.yml
+- [ ] lora_sdr_deinterleaver.block.yml
+- [ ] lora_sdr_hamming_dec.block.yml
+- [ ] lora_sdr_header_decoder.block.yml
+- [ ] lora_sdr_dewhitening.block.yml
+- [ ] lora_sdr_crc_verif.block.yml
+
 ## Summary
 This is the fully-functional GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver with all the necessary receiver components to operate correctly even at very low SNRs. The transceiver is available as a module for GNU Radio 3.10. This work has been conducted at the Telecommunication Circuits Laboratory, EPFL. 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 # Branch Info
-We implement c++ code generation capability to all blocks in this repo.
+We implement c++ code generation capability to all sub-blocks in this repo.
 This means adding the following lines to each of the blocks' .yml files: 
 
 * ```
@@ -40,7 +40,17 @@ Rx Blocks:
 - [x] lora_sdr_dewhitening.block.yml
 - [x] lora_sdr_crc_verif.block.yml
 
-Tx Blocks: to do if requested
+Tx Blocks:
+- [x] lora_sdr_data_source.block.yml
+- [x] lora_sdr_gray_demap.block.yml
+- [x] lora_sdr_hamming_enc.block.yml
+- [x] lora_sdr_header.block.yml
+- [x] lora_sdr_whitening.block.yml
+- [x] lora_sdr_payload_id_inc.block.yml
+- [x] lora_sdr_RH_RF95_header.block.yml
+- [x] lora_sdr_modulate.block.yml
+- [x] lora_sdr_interleaver.block.yml
+- [x] lora_sdr_add_crc.block.yml
 
 ## Summary
 This is the fully-functional GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver with all the necessary receiver components to operate correctly even at very low SNRs. The transceiver is available as a module for GNU Radio 3.10. This work has been conducted at the Telecommunication Circuits Laboratory, EPFL. 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We will implement c++ capability to all blocks in this repo.
 This means adding the following lines to each of the block's .yml: 
 
 * ```
-  flags: [ python, cpp ]
+  flags: [python, cpp]
   ```
 * ``` 
   cpp_templates: 
@@ -32,12 +32,12 @@ notice the <BLOCK_NAME> and <PARAMS> tag.
 for example you can look at `/grc/lora_sdr_frame_sync.block.yml` where it is already implemented
 
 Reciever Blocks to do:
-- [ ] lora_sdr_fft_demod.block.yml
-- [ ] lora_sdr_gray_mapping.block.yml
-- [ ] lora_sdr_deinterleaver.block.yml
-- [ ] lora_sdr_hamming_dec.block.yml
-- [ ] lora_sdr_header_decoder.block.yml
-- [ ] lora_sdr_dewhitening.block.yml
+- [x] lora_sdr_fft_demod.block.yml
+- [x] lora_sdr_gray_mapping.block.yml
+- [x] lora_sdr_deinterleaver.block.yml
+- [x] lora_sdr_hamming_dec.block.yml
+- [x] lora_sdr_header_decoder.block.yml
+- [x] lora_sdr_dewhitening.block.yml
 - [ ] lora_sdr_crc_verif.block.yml
 
 ## Summary

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 
 # Branch Info
-We will implement c++ capability to all blocks in this repo.
-This means adding the following lines to each of the block's .yml: 
+We implement c++ code generation capability to all blocks in this repo.
+This means adding the following lines to each of the blocks' .yml files: 
 
 * ```
   flags: [python, cpp]
@@ -31,14 +31,16 @@ This means adding the following lines to each of the block's .yml:
 notice the <BLOCK_NAME> and <PARAMS> tag.
 for example you can look at `/grc/lora_sdr_frame_sync.block.yml` where it is already implemented
 
-Reciever Blocks to do:
+Rx Blocks:
 - [x] lora_sdr_fft_demod.block.yml
 - [x] lora_sdr_gray_mapping.block.yml
 - [x] lora_sdr_deinterleaver.block.yml
 - [x] lora_sdr_hamming_dec.block.yml
 - [x] lora_sdr_header_decoder.block.yml
 - [x] lora_sdr_dewhitening.block.yml
-- [ ] lora_sdr_crc_verif.block.yml
+- [x] lora_sdr_crc_verif.block.yml
+
+Tx Blocks: to do if requested
 
 ## Summary
 This is the fully-functional GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver with all the necessary receiver components to operate correctly even at very low SNRs. The transceiver is available as a module for GNU Radio 3.10. This work has been conducted at the Telecommunication Circuits Laboratory, EPFL. 

--- a/examples/rx_cpp.grc
+++ b/examples/rx_cpp.grc
@@ -1,0 +1,234 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: no_gui
+    hier_block_src_path: '.:'
+    id: rx_cpp
+    max_nouts: '0'
+    output_language: cpp
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: rx_cpp
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: 4e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: soft_decoding
+  id: variable
+  parameters:
+    comment: ''
+    value: 'True'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [296, 12.0]
+    rotation: 0
+    state: enabled
+- name: blocks_null_source_0
+  id: blocks_null_source
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_source: '[[0,],]'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_outputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [112, 280.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_crc_verif_0
+  id: lora_sdr_crc_verif
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    output_crc_check: 'False'
+    print_rx_msg: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [712, 384.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_deinterleaver_1
+  id: lora_sdr_deinterleaver
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    soft_decoding: soft_decoding
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [880, 292.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_dewhitening_0
+  id: lora_sdr_dewhitening
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [544, 400.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_fft_demod_0
+  id: lora_sdr_fft_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    max_log_approx: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    soft_decoding: soft_decoding
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [496, 292.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_frame_sync_0
+  id: lora_sdr_frame_sync
+  parameters:
+    affinity: ''
+    alias: ''
+    bandwidth: int(500e3)
+    center_freq: int(95e6)
+    comment: ''
+    impl_head: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    os_factor: '4'
+    preamb_len: '8'
+    sf: '5'
+    show_log_port: 'False'
+    sync_word: '18'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [328, 260.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_gray_mapping_0
+  id: lora_sdr_gray_mapping
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    soft_decoding: soft_decoding
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [688, 292.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_hamming_dec_0
+  id: lora_sdr_hamming_dec
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    soft_decoding: soft_decoding
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [104, 396.0]
+    rotation: 0
+    state: enabled
+- name: lora_sdr_header_decoder_0
+  id: lora_sdr_header_decoder
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    cr: '3'
+    has_crc: 'False'
+    impl_head: 'False'
+    ldro: '2'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    pay_len: '255'
+    print_header: 'True'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [312, 396.0]
+    rotation: 0
+    state: enabled
+
+connections:
+- [blocks_null_source_0, '0', lora_sdr_frame_sync_0, '0']
+- [lora_sdr_deinterleaver_1, '0', lora_sdr_hamming_dec_0, '0']
+- [lora_sdr_dewhitening_0, '0', lora_sdr_crc_verif_0, '0']
+- [lora_sdr_fft_demod_0, '0', lora_sdr_gray_mapping_0, '0']
+- [lora_sdr_frame_sync_0, '0', lora_sdr_fft_demod_0, '0']
+- [lora_sdr_gray_mapping_0, '0', lora_sdr_deinterleaver_1, '0']
+- [lora_sdr_hamming_dec_0, '0', lora_sdr_header_decoder_0, '0']
+- [lora_sdr_header_decoder_0, '0', lora_sdr_dewhitening_0, '0']
+- [lora_sdr_header_decoder_0, frame_info, lora_sdr_frame_sync_0, frame_info]
+
+metadata:
+  file_format: 1
+  grc_version: v3.11.0.0git-645-g506e68df

--- a/grc/lora_sdr_RH_RF95_header.block.yml
+++ b/grc/lora_sdr_RH_RF95_header.block.yml
@@ -1,6 +1,7 @@
 id: lora_sdr_RH_RF95_header
 label: Rh rf95 header
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: _to
@@ -15,6 +16,18 @@ parameters:
 -   id: _flags
     label: _flags
     dtype: int
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/RH_RF95_header.h>']
+    declarations: 'lora_sdr::RH_RF95_header::sptr ${id};'
+    make: 'this->${id} = lora_sdr::RH_RF95_header::make(${_to}, ${_from}, ${_id}, ${_flags});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: message

--- a/grc/lora_sdr_add_crc.block.yml
+++ b/grc/lora_sdr_add_crc.block.yml
@@ -3,12 +3,25 @@
 id: lora_sdr_add_crc
 label: Add crc
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: has_crc
     label: Has_crc
     dtype: bool
     default: 'False'
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/add_crc.h>']
+    declarations: 'lora_sdr::add_crc::sptr ${id};'
+    make: 'this->${id} = lora_sdr::add_crc::make(${has_crc});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_crc_verif.block.yml
+++ b/grc/lora_sdr_crc_verif.block.yml
@@ -3,6 +3,7 @@
 id: lora_sdr_crc_verif
 label: CRC verif
 category: '[LoRa_RX]'
+flags: [python,cpp]
 
 parameters:
 -   id: print_rx_msg
@@ -17,6 +18,18 @@ parameters:
     options: ['False', 'True']
     option_labels: ['No', 'Yes']
     default: 'False'
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/crc_verif.h>']
+    declarations: 'lora_sdr::crc_verif::sptr ${id};'
+    make: 'this->${id} = lora_sdr::crc_verif::make(${print_rx_msg}, ${output_crc_check});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_data_source.block.yml
+++ b/grc/lora_sdr_data_source.block.yml
@@ -3,6 +3,7 @@
 id: lora_sdr_data_source
 label: Data source
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: pay_len
@@ -11,6 +12,18 @@ parameters:
 -   id: n_frames
     label: N_frames
     dtype: int
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/data_source.h>']
+    declarations: 'lora_sdr::data_source::sptr ${id};'
+    make: 'this->${id} = lora_sdr::data_source::make(${pay_len}, ${n_frames});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: message

--- a/grc/lora_sdr_deinterleaver.block.yml
+++ b/grc/lora_sdr_deinterleaver.block.yml
@@ -3,6 +3,7 @@
 id: lora_sdr_deinterleaver
 label: Deinterleaver
 category: '[LoRa_RX]'
+flags: [python,cpp]
 
 parameters:
 -   id: soft_decoding
@@ -14,6 +15,18 @@ inputs:
 -   domain: stream
     dtype: ${ 'f64' if soft_decoding else 'short'}
     vlen: ${ 12 if soft_decoding else 1} #12 is the max number of bits per symbol
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/deinterleaver.h>']
+    declarations: 'lora_sdr::deinterleaver::sptr ${id};'
+    make: 'this->${id} = lora_sdr::deinterleaver::make(${soft_decoding});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 outputs:
 -   domain: stream

--- a/grc/lora_sdr_dewhitening.block.yml
+++ b/grc/lora_sdr_dewhitening.block.yml
@@ -3,6 +3,19 @@
 id: lora_sdr_dewhitening
 label: Dewhitening
 category: '[LoRa_RX]'
+flags: [python,cpp]
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/dewhitening.h>']
+    declarations: 'lora_sdr::dewhitening::sptr ${id};'
+    make: 'this->${id} = lora_sdr::dewhitening::make();'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_fft_demod.block.yml
+++ b/grc/lora_sdr_fft_demod.block.yml
@@ -3,6 +3,7 @@
 id: lora_sdr_fft_demod
 label: fft_demod
 category: '[LoRa_RX]'
+flags: [python, cpp]
 
 parameters:
 -   id: soft_decoding
@@ -30,6 +31,18 @@ outputs:
 templates:
     imports: import gnuradio.lora_sdr as lora_sdr
     make: lora_sdr.fft_demod( ${soft_decoding}, ${max_log_approx})
+
+cpp_templates: 
+  includes: ['#include <gnuradio/lora_sdr/fft_demod.h>'] 
+  declarations: 'lora_sdr::fft_demod::sptr ${id};' 
+  make: 'this->${id} = lora_sdr::fft_demod::make(${soft_decoding}, ${max_log_approx});'
+  packages: ['gnuradio-lora_sdr']
+  link: ['gnuradio::gnuradio-lora_sdr']
+  translations:
+     'False': 'false'
+     'True': 'true'
+     \[: '{'
+     \]: '}'
 
 documentation: |-
     Recover the value of a lora symbol using argmax(DFT(lora_symbol * ref_downchirp)

--- a/grc/lora_sdr_frame_sync.block.yml
+++ b/grc/lora_sdr_frame_sync.block.yml
@@ -58,9 +58,11 @@ templates:
     make: lora_sdr.frame_sync(${center_freq}, ${bandwidth}, ${sf}, ${impl_head}, ${sync_word}, ${os_factor},${preamb_len})
 
 cpp_templates:
-    includes: ['#include "frame_sync.h"']
+    includes: ['#include <gnuradio/lora_sdr/frame_sync.h>']
     declarations: 'lora_sdr::frame_sync::sptr ${id};'
     make: 'this->${id} = lora_sdr::frame_sync::make(${center_freq}, ${bandwidth}, ${sf}, ${impl_head}, ${sync_word}, ${os_factor},${preamb_len});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
     translations:
         'False': 'false'
         'True': 'true'

--- a/grc/lora_sdr_gray_demap.block.yml
+++ b/grc/lora_sdr_gray_demap.block.yml
@@ -1,12 +1,26 @@
 id: lora_sdr_gray_demap
 label: Gray demapping
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: sf
     label: SF
     dtype: int
     default: 'sf'
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/gray_demap.h>']
+    declarations: 'lora_sdr::gray_demap::sptr ${id};'
+    make: 'this->${id} = lora_sdr::gray_demap::make(${sf});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
+
 inputs:
 -   domain: stream
     dtype: int

--- a/grc/lora_sdr_gray_mapping.block.yml
+++ b/grc/lora_sdr_gray_mapping.block.yml
@@ -1,6 +1,7 @@
 id: lora_sdr_gray_mapping
 label: Gray mapping
 category: '[LoRa_RX]'
+flags: [python,cpp]
 
 parameters:
 -   id: soft_decoding
@@ -8,6 +9,18 @@ parameters:
     dtype: bool
     default: 'soft_decoding'
     options: [False, True]
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/gray_mapping.h>']
+    declarations: 'lora_sdr::gray_mapping::sptr ${id};'
+    make: 'this->${id} = lora_sdr::gray_mapping::make(${soft_decoding});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_hamming_dec.block.yml
+++ b/grc/lora_sdr_hamming_dec.block.yml
@@ -1,6 +1,7 @@
 id: lora_sdr_hamming_dec
 label: Hamming dec
 category: '[LoRa_RX]'
+flags: [python,cpp]
 
 parameters:
 -   id: soft_decoding
@@ -8,6 +9,18 @@ parameters:
     dtype: bool
     default: 'soft_decoding'
     options: [False, True]
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/hamming_dec.h>']
+    declarations: 'lora_sdr::hamming_dec::sptr ${id};'
+    make: 'this->${id} = lora_sdr::hamming_dec::make(${soft_decoding});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_hamming_enc.block.yml
+++ b/grc/lora_sdr_hamming_enc.block.yml
@@ -3,6 +3,7 @@
 id: lora_sdr_hamming_enc
 label: Hamming enc
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: cr
@@ -13,6 +14,18 @@ parameters:
     label: SF
     dtype: int
     default: 7
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/hamming_enc.h>']
+    declarations: 'lora_sdr::hamming_enc::sptr ${id};'
+    make: 'this->${id} = lora_sdr::hamming_enc::make(${cr}, ${sf});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_header.block.yml
+++ b/grc/lora_sdr_header.block.yml
@@ -1,6 +1,7 @@
 id: lora_sdr_header
 label: Add header
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: impl_head
@@ -14,6 +15,18 @@ parameters:
     label: CR
     dtype: int
     default: 'cr'
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/header.h>']
+    declarations: 'lora_sdr::header::sptr ${id};'
+    make: 'this->${id} = lora_sdr::header::make(${impl_head}, ${has_crc}, ${cr});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 
 inputs:

--- a/grc/lora_sdr_header_decoder.block.yml
+++ b/grc/lora_sdr_header_decoder.block.yml
@@ -3,6 +3,7 @@
 id: lora_sdr_header_decoder
 label: Header decoder
 category: '[LoRa_RX]'
+flags: [python,cpp]
 
 parameters:
 -   id: impl_head
@@ -35,6 +36,17 @@ parameters:
     option_labels: ['Disable','Enable','Auto']
     default: '2'
 
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/header_decoder.h>']
+    declarations: 'lora_sdr::header_decoder::sptr ${id};'
+    make: 'this->${id} = lora_sdr::header_decoder::make(${impl_head}, ${print_header}, ${cr}, ${pay_len}, ${has_crc}, ${ldro});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_interleaver.block.yml
+++ b/grc/lora_sdr_interleaver.block.yml
@@ -1,6 +1,7 @@
 id: lora_sdr_interleaver
 label: Interleaver
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: cr
@@ -22,6 +23,18 @@ parameters:
     dtype: int
     default: '125000'
     hide: ${'none' if str(ldro) == '2' else 'all'}
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/interleaver.h>']
+    declarations: 'lora_sdr::interleaver::sptr ${id};'
+    make: 'this->${id} = lora_sdr::interleaver::make(${cr}, ${sf}, ${ldro}, ${bw});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_modulate.block.yml
+++ b/grc/lora_sdr_modulate.block.yml
@@ -3,6 +3,7 @@
 id: lora_sdr_modulate
 label: Modulate
 category: '[LoRa_TX]'
+flags: [python,cpp]
 
 parameters:
 -   id: sf
@@ -30,6 +31,18 @@ parameters:
     hide: part
     dtype: int
     default: int(20*2**sf*samp_rate/bw)
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/modulate.h>']
+    declarations: 'lora_sdr::modulate::sptr ${id};'
+    make: 'this->${id} = lora_sdr::modulate::make(${sf}, ${samp_rate}, ${bw}, ${sync_words}, ${preamb_len}, ${frame_zero_padd});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream

--- a/grc/lora_sdr_payload_id_inc.block.yml
+++ b/grc/lora_sdr_payload_id_inc.block.yml
@@ -1,6 +1,8 @@
 id: lora_sdr_payload_id_inc
 label: payload id inc
 category: '[LoRa_TX]'
+flags: [python,cpp]
+
 templates:
   imports: import gnuradio.lora_sdr as lora_sdr
   make: lora_sdr.payload_id_inc(${separator})
@@ -9,6 +11,19 @@ parameters:
   label: Separator
   dtype: string
   default: ':'
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/payload_id_inc.h>']
+    declarations: 'lora_sdr::payload_id_inc::sptr ${id};'
+    make: 'this->${id} = lora_sdr::payload_id_inc::make(${separator});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
+
 inputs: 
 -   domain: message
     id: msg_in

--- a/grc/lora_sdr_whitening.block.yml
+++ b/grc/lora_sdr_whitening.block.yml
@@ -1,6 +1,8 @@
 id: lora_sdr_whitening
 label: Whitening
 category: '[LoRa_TX]'
+flags: [python,cpp]
+
 parameters:
 -   id: source_type
     label: Source type
@@ -30,6 +32,18 @@ parameters:
     dtype: bool
     default: false
     hide: ${ ( 'none' if (str(source_type) == "file_source" and use_length_tag == 'False') else 'all') }
+
+cpp_templates:
+    includes: ['#include <gnuradio/lora_sdr/whitening.h>']
+    declarations: 'lora_sdr::whitening::sptr ${id};'
+    make: 'this->${id} = lora_sdr::whitening::make(${source_type}, ${use_length_tag}, ${separator}, ${length_tag_name}, ${is_hex});'
+    packages: ['gnuradio-lora_sdr']
+    link: ['gnuradio::gnuradio-lora_sdr']
+    translations:
+        'False': 'false'
+        'True': 'true'
+        \[: '{'
+        \]: '}'
 
 inputs:
 -   domain: stream


### PR DESCRIPTION
_Can also be merged to master (no conflicts)_
from the updated README:  **(do not merge the README.md)**

We implement c++ code generation capability to all Rx blocks in this repo.
This means adding the following lines to each of the blocks' .yml files: 

* ```
  flags: [python, cpp]
  ```
* ``` 
  cpp_templates: 
  includes: ['#include <gnuradio/lora_sdr/<BLOCK_NAME>.h>'] 
  declarations: 'lora_sdr::<BLOCK_NAME>::sptr ${id};' 
  make: 'this->${id} = lora_sdr::<BLOCK_NAME>::make(<PARAMS>);'
  packages: ['gnuradio-lora_sdr']
  link: ['gnuradio::gnuradio-lora_sdr']
  translations:
     'False': 'false'
     'True': 'true'
     \[: '{'
     \]: '}'
  ```

notice the <BLOCK_NAME> and <PARAMS> tag.
for example you can look at `/grc/lora_sdr_frame_sync.block.yml` where it is already implemented

Rx Blocks:
- [x] lora_sdr_fft_demod.block.yml
- [x] lora_sdr_gray_mapping.block.yml
- [x] lora_sdr_deinterleaver.block.yml
- [x] lora_sdr_hamming_dec.block.yml
- [x] lora_sdr_header_decoder.block.yml
- [x] lora_sdr_dewhitening.block.yml
- [x] lora_sdr_crc_verif.block.yml