### PR TITLE
Improve frame_sync_impl::get_symbol_val() performance

### DIFF
--- a/lib/frame_sync_impl.cc
+++ b/lib/frame_sync_impl.cc
@@ -79,6 +79,7 @@ namespace gr
             k_hat = 0;
             preamb_up_vals.resize(m_n_up_req, 0);
             frame_cnt = 0;
+            m_symb_numb = 0;
 
             m_kiss_fft_cfg = kiss_fft_alloc(m_number_of_bins, 0, 0, 0);
             cx_in = new kiss_fft_cpx[m_number_of_bins];
@@ -404,6 +405,7 @@ namespace gr
                 symbol_cnt = 1;
                 k_hat = 0;
                 m_sto_frac = 0;
+                m_symb_numb = 0;
             }
             else
             {

--- a/lib/frame_sync_impl.cc
+++ b/lib/frame_sync_impl.cc
@@ -80,6 +80,7 @@ namespace gr
             preamb_up_vals.resize(m_n_up_req, 0);
             frame_cnt = 0;
 
+            m_kiss_fft_cfg = kiss_fft_alloc(m_number_of_bins, 0, 0, 0);
             cx_in = new kiss_fft_cpx[m_number_of_bins];
             cx_out = new kiss_fft_cpx[m_number_of_bins];
             // register message ports
@@ -105,6 +106,7 @@ namespace gr
          */
         frame_sync_impl::~frame_sync_impl()
         {
+            kiss_fft_free(m_kiss_fft_cfg);
         }
         int frame_sync_impl::my_roundf(float number)
         {
@@ -320,8 +322,6 @@ namespace gr
             std::vector<float> fft_mag(m_number_of_bins);
             volk::vector<gr_complex> dechirped(m_number_of_bins);
 
-            kiss_fft_cfg cfg = kiss_fft_alloc(m_number_of_bins, 0, 0, 0);
-
             // Multiply with ideal downchirp
             volk_32fc_x2_multiply_32fc(&dechirped[0], samples, ref_chirp, m_number_of_bins);
 
@@ -331,7 +331,7 @@ namespace gr
                 cx_in[i].i = dechirped[i].imag();
             }
             // do the FFT
-            kiss_fft(cfg, cx_in, cx_out);
+            kiss_fft(m_kiss_fft_cfg, cx_in, cx_out);
 
             // Get magnitude
             for (uint32_t i = 0u; i < m_number_of_bins; i++)
@@ -339,7 +339,6 @@ namespace gr
                 fft_mag[i] = cx_out[i].r * cx_out[i].r + cx_out[i].i * cx_out[i].i;
                 sig_en += fft_mag[i];
             }
-            free(cfg);
             // Return argmax here
 
             return sig_en ? (std::distance(std::begin(fft_mag), std::max_element(std::begin(fft_mag), std::end(fft_mag)))) : -1;

--- a/lib/frame_sync_impl.cc
+++ b/lib/frame_sync_impl.cc
@@ -107,6 +107,8 @@ namespace gr
          */
         frame_sync_impl::~frame_sync_impl()
         {
+            delete[] cx_out;
+            delete[] cx_in;
             kiss_fft_free(m_kiss_fft_cfg);
         }
         int frame_sync_impl::my_roundf(float number)

--- a/lib/frame_sync_impl.h
+++ b/lib/frame_sync_impl.h
@@ -72,6 +72,7 @@ namespace gr
       uint16_t m_preamb_len; ///< Number of consecutive upchirps in preamble
       uint8_t additional_upchirps; ///< indicate the number of additional upchirps found in preamble (in addition to the minimum required to trigger a detection)
 
+      kiss_fft_cfg m_kiss_fft_cfg; ///< FFT configuration for symbols processing
       kiss_fft_cpx *cx_in;  ///<input of the FFT
       kiss_fft_cpx *cx_out; ///<output of the FFT
 


### PR DESCRIPTION
On Apple M3 hyperfine shows 22% of improvement:
```
Benchmark 1: python3 gr_meshtastic.py
  Time (mean ± σ):     428.8 ms ±   6.7 ms    [User: 420.3 ms, System: 81.5 ms]
  Range (min … max):   420.8 ms … 439.1 ms    10 runs
```
```
Benchmark 1: python3 gr_meshtastic.py
  Time (mean ± σ):     335.1 ms ±   1.6 ms    [User: 326.2 ms, System: 79.8 ms]
  Range (min … max):   332.7 ms … 337.0 ms    10 runs
```

On RPi4 the improvement is about 13% (8.12s to 7.09s). Some details on the benchmarking setup are in https://github.com/tapparelj/gr-lora_sdr/issues/92.

There are other places in the code where a state returned by kiss_fft_alloc() is not reused, but it seems that they are not on the hot path.