### PR TITLE
Skip netid2 check if requested

### DIFF
--- a/lib/frame_sync_impl.cc
+++ b/lib/frame_sync_impl.cc
@@ -705,7 +705,14 @@ namespace gr
                     int netid2 = get_symbol_val(&net_ids_samp_dec[m_number_of_bins], &m_downchirp[0]);
                     one_symbol_off = 0;
 
-                    if (abs(netid1 - (int32_t)m_sync_words[0]) > 2) // wrong id 1, (we allow an offset of 2)
+                    if (m_sync_words[0] == 0) { // match netid1 only if requested
+                        items_to_consume = 0;
+                        m_state = SFO_COMPENSATION;
+                        frame_cnt++;
+                        std::cout << "netid1 is " << netid1 << ", netid2 is " << netid2 <<
+                            ", check skipped" << std::endl;
+                    }
+                    else if (abs(netid1 - (int32_t)m_sync_words[0]) > 2) // wrong id 1, (we allow an offset of 2)
                     {
 
                         // check if we are in fact checking the second net ID and that the first one was considered as a preamble upchirp

--- a/lib/frame_sync_impl.cc
+++ b/lib/frame_sync_impl.cc
@@ -759,7 +759,8 @@ namespace gr
                     else // net ID 1 valid
                     {
                         net_id_off = netid1 - (int32_t)m_sync_words[0];
-                        if (mod(netid2 - net_id_off, m_number_of_bins) != (int32_t)m_sync_words[1]) // wrong id 2
+                        if (m_sync_words[1] != 0 && // match netid2 only if requested
+                            mod(netid2 - net_id_off, m_number_of_bins) != (int32_t)m_sync_words[1]) // wrong id 2
                         {
                             m_state = DETECT;
                             symbol_cnt = 1;
@@ -777,6 +778,8 @@ namespace gr
                             items_to_consume = -m_os_factor * net_id_off;
                             m_state = SFO_COMPENSATION;
                             frame_cnt++;
+                            if (m_sync_words[1] == 0)
+                                std::cout << "netid2 is " << netid2 << std::endl;
                         }
                     }
                     if (m_state != DETECT)


### PR DESCRIPTION
It seems that a complete decoding of SX1272/62 sync words would require an additional reverse engineering effort of how exactly these chips generate the frame sync portion of a packet. According to [this research](https://blog.classycode.com/lora-sync-word-compatibility-between-sx127x-and-sx126x-460324d1787a), there are some opaque intricacies indeed, and there are rumors that no other values except 0x3444/0x1424 are recommended for use.

This change (partially) works around the issue by skipping the check of the second sync word if requested. To skip, set the second part of the Frame Sync block parameter to zero, e.g. [16, 0]. According to the link above, zero word is invalid anyway so it presumably can be used for this purpose.

A bit more of details are in https://github.com/tapparelj/gr-lora_sdr/issues/91#issuecomment-2090505978.