### PR TITLE
Update conda-smithy recipe

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -1,7 +1,9 @@
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +13,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -1,7 +1,9 @@
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +13,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,9 @@
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +13,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
@@ -1,33 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+ace:
+- 8.0.1
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '16'
+- '13'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - tapparelj main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+gmp:
+- '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
-macos_machine:
-- arm64-apple-darwin20.0.0
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
@@ -1,9 +1,11 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____cpython.yaml
@@ -1,9 +1,11 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
@@ -1,9 +1,11 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.26python3.12.____cpython.yaml
@@ -1,9 +1,11 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,23 +17,23 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
@@ -1,7 +1,9 @@
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +13,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpython.yaml
@@ -1,7 +1,9 @@
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +13,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
@@ -1,7 +1,9 @@
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +13,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:

--- a/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpython.yaml
@@ -1,7 +1,9 @@
+ace:
+- 8.0.1
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,23 +13,23 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -1,9 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+ace:
+- 8.0.1
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,9 +15,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 macos_machine:

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -1,9 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+ace:
+- 8.0.1
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,9 +15,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 macos_machine:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -1,9 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+ace:
+- 8.0.1
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,9 +15,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 macos_machine:

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
@@ -1,9 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+ace:
+- 8.0.1
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,21 +15,21 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -1,9 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+ace:
+- 8.0.1
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,9 +15,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 macos_machine:

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -1,9 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+ace:
+- 8.0.1
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,9 +15,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 macos_machine:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -1,9 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+ace:
+- 8.0.1
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,9 +15,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
 macos_machine:

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -1,35 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+ace:
+- 8.0.1
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos7
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
 - tapparelj main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-gmp:
-- '6'
+- '17'
 gnuradio_core:
-- 3.10.6
+- 3.10.11
 gnuradio_extra_pin:
 - ''
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.conda/recipe/conda_build_config.yaml
+++ b/.conda/recipe/conda_build_config.yaml
@@ -5,7 +5,7 @@ channel_targets:
 # override the conda-forge pin for gnuradio-core by uncommenting
 # and specifying a different version here
 gnuradio_core:
-  - "3.10.6"
+  - "3.10.11"
 gnuradio_extra_pin:
   # always leave one entry with the empty string
   - ""

--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -9,118 +9,119 @@
 {% set version = (tag_version if post_commit == "0" else "{0}.post{1}+{2}".format(tag_version, post_commit, hash)) if tag_version else fallback_version %}
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  # use local path or git repository depending on if the build is local or done on CI
-  path: "../.."  # [not os.environ.get("CI")]
-  git_url: {{ environ.get('FEEDSTOCK_ROOT', "../..") }}  # [os.environ.get("CI")]
+  # use local path or git repository depending on if the build is local or done on CI
+  path: "../.."  # [not os.environ.get("CI")]
+  git_url: {{ environ.get('FEEDSTOCK_ROOT', "../..") }}  # [os.environ.get("CI")]
 
 build:
-  number: 0
-  skip: true  # [win]
-  skip: true  # [py>=312]
-  
+  number: 0
+  skip: true  # [win]
+  skip: true  # [py>=313]
+  
 requirements:
-  build:
-    - {{ compiler("c") }}
-    - {{ compiler("cxx") }}
-    - cmake
-    - git
-    - ninja
-    - pkg-config
-    # cross-compilation requirements
-    - python                              # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
-    - numpy                               # [build_platform != target_platform]
-    - pybind11                            # [build_platform != target_platform]
-    # Add extra build tool dependencies here
-    - boost-cpp=1.78.0
-    - volk=3.0.0
+  build:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - cmake
+    - git
+    - ninja
+    - pkg-config
+    # cross-compilation requirements
+    - python                              # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+    - numpy                               # [build_platform != target_platform]
+    - pybind11                            # [build_platform != target_platform]
+    # Add extra build tool dependencies here
+    - boost-cpp=1.84.0
+    - volk=3.1.2
 
-  host:
-    - gmp  # [linux]
-    # the following two entries are for generating builds against specific GR versions
-    - gnuradio-core  # [not gnuradio_extra_pin]
-    - gnuradio-core {{ gnuradio_extra_pin }}.*  # [gnuradio_extra_pin]
-    - pip  # [win]
-    - pybind11
-    - python
-    - numpy
-    # Add/remove library dependencies here
-    - boost-cpp=1.78.0
-    - volk=3.0.0
+  host:
+    - gmp  # [linux]
+    # the following two entries are for generating builds against specific GR versions
+    - gnuradio-core  # [not gnuradio_extra_pin]
+    - gnuradio-core {{ gnuradio_extra_pin }}.*  # [gnuradio_extra_pin]
+    - pip  # [win]
+    - pybind11
+    - python
+    - numpy
+    # Add/remove library dependencies here
+    - boost-cpp=1.84.0
+    - volk=3.1.2
 
-  run:
-    - numpy
-    - python
-    # Add/remove runtime dependencies here
-    - boost-cpp=1.78.0
-    - volk=3.0.0
+  run:
+    - numpy
+    - python
+    # Add/remove runtime dependencies here
+    - boost-cpp=1.84.0
+    - volk=3.1.2
 
 test:
-  requires:
-    - gnuradio-grc
-    - gnuradio-uhd
-  commands:
-    ## verify that commands run
-    #- COMMAND --help
+  requires:
+    - gnuradio-grc
+    - gnuradio-uhd
+  commands:
+    ## verify that commands run
+    #- COMMAND --help
 
-    # verify that (some) headers get installed
-    - test -f $PREFIX/include/gnuradio/{{ oot_name }}/api.h  # [not win]
-    - if not exist %PREFIX%\\Library\\include\\gnuradio\\{{ oot_name }}\\api.h exit 1  # [win]
+    # verify that (some) headers get installed
+    - test -f $PREFIX/include/gnuradio/{{ oot_name }}/api.h  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\gnuradio\\{{ oot_name }}\\api.h exit 1  # [win]
 
-    # verify that libraries get installed
-    - test -f $PREFIX/lib/lib{{ name }}${SHLIB_EXT}  # [not win]
-    - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
+    # verify that libraries get installed
+    - test -f $PREFIX/lib/lib{{ name }}${SHLIB_EXT}  # [not win]
+    - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
 
-    # verify that (some) GRC blocks get installed
-    {% set blocks = ["lora_rx", "lora_tx", "header", "header_decoder", "modulate"] %}
-    {% for block in blocks %}
-    - test -f $PREFIX/share/gnuradio/grc/blocks/{{ oot_name }}_{{ block }}.block.yml  # [not win]
-    - if not exist %PREFIX%\\Library\\share\\gnuradio\\grc\\blocks\\{{ oot_name }}_{{ block }}.block.yml exit 1  # [win]
-    {% endfor %}
+    # verify that (some) GRC blocks get installed
+    {% set blocks = ["lora_rx", "lora_tx", "header", "header_decoder", "modulate"] %}
+    {% for block in blocks %}
+    - test -f $PREFIX/share/gnuradio/grc/blocks/{{ oot_name }}_{{ block }}.block.yml  # [not win]
+    - if not exist %PREFIX%\\Library\\share\\gnuradio\\grc\\blocks\\{{ oot_name }}_{{ block }}.block.yml exit 1  # [win]
+    {% endfor %}
 
-    # verify that examples get installed
-    {% set example_grcs = ["lora_RX", "lora_TX", "tx_rx_functionality_check", "tx_rx_simulation", "tx_rx_usrp"] %}
-    {% for eg in example_grcs %}
-    - grcc $PREFIX/share/gr-{{ oot_name }}/examples/{{ eg }}.grc  # [not win]
-    - grcc %PREFIX%\\Library\\share\\gr-{{ oot_name}}\\examples\\{{ eg }}.grc  # [win]
-    {% endfor %}
+    # verify that examples get installed
+    {% set example_grcs = ["lora_RX", "lora_TX", "tx_rx_functionality_check", "tx_rx_simulation", "tx_rx_usrp"] %}
+    {% for eg in example_grcs %}
+    - grcc $PREFIX/share/gr-{{ oot_name }}/examples/{{ eg }}.grc  # [not win]
+    - grcc %PREFIX%\\Library\\share\\gr-{{ oot_name}}\\examples\\{{ eg }}.grc  # [win]
+    {% endfor %}
 
-  imports:
-    # verify that the python module imports
-    - gnuradio.{{ oot_name }}
+  imports:
+    # verify that the python module imports
+    - gnuradio.{{ oot_name }}
 
 about:
-  home: https://github.com/tapparelj/gr-lora_sdr
-  license: GPL-3.0-or-later
-  license_file: LICENSE
-  summary: GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver
-  description: >
-    This is the fully-functional GNU Radio software-defined radio (SDR)
-    implementation of a LoRa transceiver with all the necessary receiver
-    components to operate correctly even at very low SNRs. The transceiver is
-    available as a module for GNU Radio 3.10. This work has been conducted at
-    the Telecommunication Circuits Laboratory, EPFL.<br>
+  home: https://github.com/tapparelj/gr-lora_sdr
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  summary: GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver
+  description: >
+    This is the fully-functional GNU Radio software-defined radio (SDR)
+    implementation of a LoRa transceiver with all the necessary receiver
+    components to operate correctly even at very low SNRs. The transceiver is
+    available as a module for GNU Radio 3.10. This work has been conducted at
+    the Telecommunication Circuits Laboratory, EPFL.<br>
 
-    In the GNU Radio implementation of the LoRa Tx and Rx chains the user can
-    choose all the parameters of the transmission, such as the spreading
-    factor, the coding rate, the bandwidth, the sync word, the presence of an
-    explicit header and CRC.<br>
+    In the GNU Radio implementation of the LoRa Tx and Rx chains the user can
+    choose all the parameters of the transmission, such as the spreading
+    factor, the coding rate, the bandwidth, the sync word, the presence of an
+    explicit header and CRC.<br>
 
-    Example gnuradio-companion flowgraphs are installed with the package and can be found in:
+    Example gnuradio-companion flowgraphs are installed with the package and can be found in:
 
-        - (Linux/macOS) `$CONDA_PREFIX/share/gr-lora_sdr/examples`
-        - (Windows) `%CONDA_PREFIX%\share\gr-lora_sdr\examples`
-    <br>
-    If you find this module useful for your project, please consider citing the
-    publication "An Open-Source LoRa Physical Layer Prototype on GNU Radio" 
-    (<a href="https://ieeexplore.ieee.org/document/9154273">IEEE Xplore</a>,  
-    <a href="https://arxiv.org/abs/2002.08208">arXiv</a>)
-    <h3>Installation issue</h3>
-    Add conda-forge to the list of channel for installation with:<br>
-    `conda install -c tapparelj -c conda-forge gnuradio-lora_sdr`
-    
+        - (Linux/macOS) `$CONDA_PREFIX/share/gr-lora_sdr/examples`
+        - (Windows) `%CONDA_PREFIX%\share\gr-lora_sdr\examples`
+    <br>
+    If you find this module useful for your project, please consider citing the
+    publication "An Open-Source LoRa Physical Layer Prototype on GNU Radio" 
+    (<a href="https://ieeexplore.ieee.org/document/9154273">IEEE Xplore</a>,  
+    <a href="https://arxiv.org/abs/2002.08208">arXiv</a>)
+    <h3>Installation issue</h3>
+    Add conda-forge to the list of channel for installation with:<br>
+    `conda install -c tapparelj -c conda-forge gnuradio-lora_sdr`
+
+

--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -9,119 +9,118 @@
 {% set version = (tag_version if post_commit == "0" else "{0}.post{1}+{2}".format(tag_version, post_commit, hash)) if tag_version else fallback_version %}
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  # use local path or git repository depending on if the build is local or done on CI
-  path: "../.."  # [not os.environ.get("CI")]
-  git_url: {{ environ.get('FEEDSTOCK_ROOT', "../..") }}  # [os.environ.get("CI")]
+  # use local path or git repository depending on if the build is local or done on CI
+  path: "../.."  # [not os.environ.get("CI")]
+  git_url: {{ environ.get('FEEDSTOCK_ROOT', "../..") }}  # [os.environ.get("CI")]
 
 build:
-  number: 0
-  skip: true  # [win]
-  skip: true  # [py>=313]
-  
+  number: 0
+  skip: true  # [win]
+  skip: true  # [py>=313]
+  
 requirements:
-  build:
-    - {{ compiler("c") }}
-    - {{ compiler("cxx") }}
-    - cmake
-    - git
-    - ninja
-    - pkg-config
-    # cross-compilation requirements
-    - python                              # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
-    - numpy                               # [build_platform != target_platform]
-    - pybind11                            # [build_platform != target_platform]
-    # Add extra build tool dependencies here
-    - boost-cpp=1.84.0
-    - volk=3.1.2
+  build:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - cmake
+    - git
+    - ninja
+    - pkg-config
+    # cross-compilation requirements
+    - python                              # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+    - numpy                               # [build_platform != target_platform]
+    - pybind11                            # [build_platform != target_platform]
+    # Add extra build tool dependencies here
+    - boost-cpp=1.84.0
+    - volk=3.1.2
 
-  host:
-    - gmp  # [linux]
-    # the following two entries are for generating builds against specific GR versions
-    - gnuradio-core  # [not gnuradio_extra_pin]
-    - gnuradio-core {{ gnuradio_extra_pin }}.*  # [gnuradio_extra_pin]
-    - pip  # [win]
-    - pybind11
-    - python
-    - numpy
-    # Add/remove library dependencies here
-    - boost-cpp=1.84.0
-    - volk=3.1.2
+  host:
+    - gmp  # [linux]
+    # the following two entries are for generating builds against specific GR versions
+    - gnuradio-core  # [not gnuradio_extra_pin]
+    - gnuradio-core {{ gnuradio_extra_pin }}.*  # [gnuradio_extra_pin]
+    - pip  # [win]
+    - pybind11
+    - python
+    - numpy
+    # Add/remove library dependencies here
+    - boost-cpp=1.84.0
+    - volk=3.1.2
 
-  run:
-    - numpy
-    - python
-    # Add/remove runtime dependencies here
-    - boost-cpp=1.84.0
-    - volk=3.1.2
+  run:
+    - numpy
+    - python
+    # Add/remove runtime dependencies here
+    - boost-cpp=1.84.0
+    - volk=3.1.2
 
 test:
-  requires:
-    - gnuradio-grc
-    - gnuradio-uhd
-  commands:
-    ## verify that commands run
-    #- COMMAND --help
+  requires:
+    - gnuradio-grc
+    - gnuradio-uhd
+  commands:
+    ## verify that commands run
+    #- COMMAND --help
 
-    # verify that (some) headers get installed
-    - test -f $PREFIX/include/gnuradio/{{ oot_name }}/api.h  # [not win]
-    - if not exist %PREFIX%\\Library\\include\\gnuradio\\{{ oot_name }}\\api.h exit 1  # [win]
+    # verify that (some) headers get installed
+    - test -f $PREFIX/include/gnuradio/{{ oot_name }}/api.h  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\gnuradio\\{{ oot_name }}\\api.h exit 1  # [win]
 
-    # verify that libraries get installed
-    - test -f $PREFIX/lib/lib{{ name }}${SHLIB_EXT}  # [not win]
-    - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
+    # verify that libraries get installed
+    - test -f $PREFIX/lib/lib{{ name }}${SHLIB_EXT}  # [not win]
+    - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
 
-    # verify that (some) GRC blocks get installed
-    {% set blocks = ["lora_rx", "lora_tx", "header", "header_decoder", "modulate"] %}
-    {% for block in blocks %}
-    - test -f $PREFIX/share/gnuradio/grc/blocks/{{ oot_name }}_{{ block }}.block.yml  # [not win]
-    - if not exist %PREFIX%\\Library\\share\\gnuradio\\grc\\blocks\\{{ oot_name }}_{{ block }}.block.yml exit 1  # [win]
-    {% endfor %}
+    # verify that (some) GRC blocks get installed
+    {% set blocks = ["lora_rx", "lora_tx", "header", "header_decoder", "modulate"] %}
+    {% for block in blocks %}
+    - test -f $PREFIX/share/gnuradio/grc/blocks/{{ oot_name }}_{{ block }}.block.yml  # [not win]
+    - if not exist %PREFIX%\\Library\\share\\gnuradio\\grc\\blocks\\{{ oot_name }}_{{ block }}.block.yml exit 1  # [win]
+    {% endfor %}
 
-    # verify that examples get installed
-    {% set example_grcs = ["lora_RX", "lora_TX", "tx_rx_functionality_check", "tx_rx_simulation", "tx_rx_usrp"] %}
-    {% for eg in example_grcs %}
-    - grcc $PREFIX/share/gr-{{ oot_name }}/examples/{{ eg }}.grc  # [not win]
-    - grcc %PREFIX%\\Library\\share\\gr-{{ oot_name}}\\examples\\{{ eg }}.grc  # [win]
-    {% endfor %}
+    # verify that examples get installed
+    {% set example_grcs = ["lora_RX", "lora_TX", "tx_rx_functionality_check", "tx_rx_simulation", "tx_rx_usrp"] %}
+    {% for eg in example_grcs %}
+    - grcc $PREFIX/share/gr-{{ oot_name }}/examples/{{ eg }}.grc  # [not win]
+    - grcc %PREFIX%\\Library\\share\\gr-{{ oot_name}}\\examples\\{{ eg }}.grc  # [win]
+    {% endfor %}
 
-  imports:
-    # verify that the python module imports
-    - gnuradio.{{ oot_name }}
+  imports:
+    # verify that the python module imports
+    - gnuradio.{{ oot_name }}
 
 about:
-  home: https://github.com/tapparelj/gr-lora_sdr
-  license: GPL-3.0-or-later
-  license_file: LICENSE
-  summary: GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver
-  description: >
-    This is the fully-functional GNU Radio software-defined radio (SDR)
-    implementation of a LoRa transceiver with all the necessary receiver
-    components to operate correctly even at very low SNRs. The transceiver is
-    available as a module for GNU Radio 3.10. This work has been conducted at
-    the Telecommunication Circuits Laboratory, EPFL.<br>
+  home: https://github.com/tapparelj/gr-lora_sdr
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  summary: GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver
+  description: >
+    This is the fully-functional GNU Radio software-defined radio (SDR)
+    implementation of a LoRa transceiver with all the necessary receiver
+    components to operate correctly even at very low SNRs. The transceiver is
+    available as a module for GNU Radio 3.10. This work has been conducted at
+    the Telecommunication Circuits Laboratory, EPFL.<br>
 
-    In the GNU Radio implementation of the LoRa Tx and Rx chains the user can
-    choose all the parameters of the transmission, such as the spreading
-    factor, the coding rate, the bandwidth, the sync word, the presence of an
-    explicit header and CRC.<br>
+    In the GNU Radio implementation of the LoRa Tx and Rx chains the user can
+    choose all the parameters of the transmission, such as the spreading
+    factor, the coding rate, the bandwidth, the sync word, the presence of an
+    explicit header and CRC.<br>
 
-    Example gnuradio-companion flowgraphs are installed with the package and can be found in:
+    Example gnuradio-companion flowgraphs are installed with the package and can be found in:
 
-        - (Linux/macOS) `$CONDA_PREFIX/share/gr-lora_sdr/examples`
-        - (Windows) `%CONDA_PREFIX%\share\gr-lora_sdr\examples`
-    <br>
-    If you find this module useful for your project, please consider citing the
-    publication "An Open-Source LoRa Physical Layer Prototype on GNU Radio" 
-    (<a href="https://ieeexplore.ieee.org/document/9154273">IEEE Xplore</a>,  
-    <a href="https://arxiv.org/abs/2002.08208">arXiv</a>)
-    <h3>Installation issue</h3>
-    Add conda-forge to the list of channel for installation with:<br>
-    `conda install -c tapparelj -c conda-forge gnuradio-lora_sdr`
-
-
+        - (Linux/macOS) `$CONDA_PREFIX/share/gr-lora_sdr/examples`
+        - (Windows) `%CONDA_PREFIX%\share\gr-lora_sdr\examples`
+    <br>
+    If you find this module useful for your project, please consider citing the
+    publication "An Open-Source LoRa Physical Layer Prototype on GNU Radio" 
+    (<a href="https://ieeexplore.ieee.org/document/9154273">IEEE Xplore</a>,  
+    <a href="https://arxiv.org/abs/2002.08208">arXiv</a>)
+    <h3>Installation issue</h3>
+    Add conda-forge to the list of channel for installation with:<br>
+    `conda install -c tapparelj -c conda-forge gnuradio-lora_sdr`
+    

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -29,12 +29,6 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-          - CONFIG: linux_64_numpy1.22python3.8.____cpython
-            SHORT_CONFIG: linux_64_numpy1.22python3.8.____cpython
-            UPLOAD_PACKAGES: True
-            os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
           - CONFIG: linux_64_numpy1.22python3.9.____cpython
             SHORT_CONFIG: linux_64_numpy1.22python3.9.____cpython
             UPLOAD_PACKAGES: True
@@ -47,14 +41,14 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-          - CONFIG: linux_aarch64_numpy1.22python3.10.____cpython
-            SHORT_CONFIG: linux_aarch64_numpy1.22python3.10.____cpython
+          - CONFIG: linux_64_numpy1.26python3.12.____cpython
+            SHORT_CONFIG: linux_64_numpy1.26python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-          - CONFIG: linux_aarch64_numpy1.22python3.8.____cpython
-            SHORT_CONFIG: linux_aarch64_numpy1.22python3.8.____cpython
+          - CONFIG: linux_aarch64_numpy1.22python3.10.____cpython
+            SHORT_CONFIG: linux_aarch64_numpy1.22python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -71,14 +65,14 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-          - CONFIG: linux_ppc64le_numpy1.22python3.10.____cpython
-            SHORT_CONFIG: linux_ppc64le_numpy1.22python3.10.____cpython
+          - CONFIG: linux_aarch64_numpy1.26python3.12.____cpython
+            SHORT_CONFIG: linux_aarch64_numpy1.26python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-          - CONFIG: linux_ppc64le_numpy1.22python3.8.____cpython
-            SHORT_CONFIG: linux_ppc64le_numpy1.22python3.8.____cpython
+          - CONFIG: linux_ppc64le_numpy1.22python3.10.____cpython
+            SHORT_CONFIG: linux_ppc64le_numpy1.22python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -95,13 +89,14 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+          - CONFIG: linux_ppc64le_numpy1.26python3.12.____cpython
+            SHORT_CONFIG: linux_ppc64le_numpy1.26python3.12.____cpython
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
           - CONFIG: osx_64_numpy1.22python3.10.____cpython
             SHORT_CONFIG: osx_64_numpy1.22python3.10.____cpython
-            UPLOAD_PACKAGES: True
-            os: macos
-            runs_on: ['macos-13']
-          - CONFIG: osx_64_numpy1.22python3.8.____cpython
-            SHORT_CONFIG: osx_64_numpy1.22python3.8.____cpython
             UPLOAD_PACKAGES: True
             os: macos
             runs_on: ['macos-13']
@@ -115,13 +110,13 @@ jobs:
             UPLOAD_PACKAGES: True
             os: macos
             runs_on: ['macos-13']
-          - CONFIG: osx_arm64_numpy1.22python3.10.____cpython
-            SHORT_CONFIG: osx_arm64_numpy1.22python3.10.____cpython
+          - CONFIG: osx_64_numpy1.26python3.12.____cpython
+            SHORT_CONFIG: osx_64_numpy1.26python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: macos
             runs_on: ['macos-13']
-          - CONFIG: osx_arm64_numpy1.22python3.8.____cpython
-            SHORT_CONFIG: osx_arm64_numpy1.22python3.8.____cpython
+          - CONFIG: osx_arm64_numpy1.22python3.10.____cpython
+            SHORT_CONFIG: osx_arm64_numpy1.22python3.10.____cpython
             UPLOAD_PACKAGES: True
             os: macos
             runs_on: ['macos-13']
@@ -135,10 +130,15 @@ jobs:
             UPLOAD_PACKAGES: True
             os: macos
             runs_on: ['macos-13']
+          - CONFIG: osx_arm64_numpy1.26python3.12.____cpython
+            SHORT_CONFIG: osx_arm64_numpy1.26python3.12.____cpython
+            UPLOAD_PACKAGES: True
+            os: macos
+            runs_on: ['macos-13']
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
         fetch-depth: 0
 
@@ -191,13 +191,6 @@ jobs:
         fi
         ./.scripts/run_osx_build.sh
 
-    - name: Install Miniconda for windows
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-version: latest
-        miniforge-variant: Mambaforge
-      if: matrix.os == 'windows'
-
     - name: Build on windows
       shell: cmd
       run: |
@@ -206,6 +199,7 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
+        MINIFORGE_HOME: D:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
@@ -221,6 +215,7 @@ jobs:
         CONFIG: ${{ matrix.CONFIG }}
         SHORT_CONFIG: ${{ matrix.SHORT_CONFIG }}
         OS: ${{ matrix.os }}
+        MINIFORGE_HOME_WIN: D:\Miniforge
       run: |
         export CI=github_actions
         export CI_RUN_ID=$GITHUB_RUN_ID
@@ -229,7 +224,7 @@ jobs:
         if [ $OS == "macos" ]; then
           export CONDA_BLD_DIR="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
         elif [ $OS == "windows" ]; then
-          export CONDA_BLD_DIR="${CONDA//\\//}/conda-bld"
+          export CONDA_BLD_DIR="${MINIFORGE_HOME_WIN//\\//}/conda-bld"
         else
           export CONDA_BLD_DIR="build_artifacts"
         fi
@@ -248,7 +243,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: ${{ always() && steps.prepare-artifacts.outcome == 'success' }}
       with:
         name: ${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}
@@ -257,7 +252,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build environment artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       if: ${{ failure() && steps.prepare-artifacts.outcome == 'success' }}
       with:
         name: ${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -138,7 +138,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      uses: actions/checkout@4
       with:
         fetch-depth: 0
 
@@ -243,7 +243,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build artifacts
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      uses: actions/upload-artifact@4
       if: ${{ always() && steps.prepare-artifacts.outcome == 'success' }}
       with:
         name: ${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}
@@ -252,7 +252,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build environment artifacts
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      uses: actions/upload-artifact@4
       if: ${{ failure() && steps.prepare-artifacts.outcome == 'success' }}
       with:
         name: ${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -138,7 +138,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@4
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -243,7 +243,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build artifacts
-      uses: actions/upload-artifact@4
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.prepare-artifacts.outcome == 'success' }}
       with:
         name: ${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}
@@ -252,7 +252,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build environment artifacts
-      uses: actions/upload-artifact@4
+      uses: actions/upload-artifact@v4
       if: ${{ failure() && steps.prepare-artifacts.outcome == 'success' }}
       with:
         name: ${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,17 +31,19 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
+mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
+echo > /opt/conda/conda-meta/history
+micromamba install --root-prefix ~/.conda --prefix /opt/conda \
+    --yes --override-channels --channel conda-forge --strict-channel-priority \
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
-
-mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
+
+
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -72,6 +74,12 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir "${RECIPE_ROOT}" -m "${CONFIG_FILE}" || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
 
     ( startgroup "Uploading packages" ) 2> /dev/null
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -7,28 +7,39 @@ source .scripts/logging_utils.sh
 set -xe
 
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
+MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
 
-( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
-
-MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Mambaforge-MacOSX-$(uname -m).sh"
-curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
-rm -rf ${MINIFORGE_HOME}
-bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
-
-( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
+MICROMAMBA_VERSION="1.5.10-0"
+if [[ "$(uname -m)" == "arm64" ]]; then
+  osx_arch="osx-arm64"
+else
+  osx_arch="osx-64"
+fi
+MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
+MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
+echo "Downloading micromamba ${MICROMAMBA_VERSION}"
+micromamba_exe="$(mktemp -d)/micromamba"
+curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
+chmod +x "${micromamba_exe}"
+echo "Creating environment"
+"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
+  --channel conda-forge \
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
+mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
+echo "Cleaning up micromamba"
+rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
+( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
+source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
 conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
-mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+
 
 
 
@@ -85,6 +96,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir ./.conda/recipe -m ./.ci_support/${CONFIG}.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
 
     ( startgroup "Uploading packages" ) 2> /dev/null
 


### PR DESCRIPTION
- Bump gnuradio to the latest stable release
- Bump build dependencies (boost-cpp, volk)
- Enable CI for Python 3.12

Python 3.8 targets are removed as its EOL date is 2024-10-07.

Please let me know if you would like the "conda smithy rerender" commits taken out from this PR and submitted separately.