### PR TITLE
Update MANIFEST to yaml format and install examples to discoverable dir

### DIFF
--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -86,8 +86,8 @@ test:
     # verify that examples get installed
     {% set example_grcs = ["lora_RX", "lora_TX", "tx_rx_functionality_check", "tx_rx_simulation", "tx_rx_usrp"] %}
     {% for eg in example_grcs %}
-    - grcc $PREFIX/share/gr-{{ oot_name }}/examples/{{ eg }}.grc  # [not win]
-    - grcc %PREFIX%\\Library\\share\\gr-{{ oot_name}}\\examples\\{{ eg }}.grc  # [win]
+    - grcc $PREFIX/share/gnuradio/examples/{{ oot_name }}/{{ eg }}.grc  # [not win]
+    - grcc %PREFIX%\\Library\\share\\gnuradio\\examples\\{{ oot_name }}\\{{ eg }}.grc  # [win]
     {% endfor %}
 
   imports:
@@ -117,10 +117,10 @@ about:
         - (Windows) `%CONDA_PREFIX%\share\gr-lora_sdr\examples`
     <br>
     If you find this module useful for your project, please consider citing the
-    publication "An Open-Source LoRa Physical Layer Prototype on GNU Radio" 
-    (<a href="https://ieeexplore.ieee.org/document/9154273">IEEE Xplore</a>,  
+    publication "An Open-Source LoRa Physical Layer Prototype on GNU Radio"
+    (<a href="https://ieeexplore.ieee.org/document/9154273">IEEE Xplore</a>,
     <a href="https://arxiv.org/abs/2002.08208">arXiv</a>)
     <h3>Installation issue</h3>
     Add conda-forge to the list of channel for installation with:<br>
     `conda install -c tapparelj -c conda-forge gnuradio-lora_sdr`
-    
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In GNU Radio 3.9+, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,3 +166,6 @@ configure_package_config_file(
     INSTALL_DESTINATION ${GR_CMAKE_DIR}
 )
 
+install(FILES MANIFEST.yml
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.yml
+    DESTINATION share/gnuradio/manifests/lora_sdr)

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,0 +1,19 @@
+title: The LORA_SDR OOT Module
+version: 1.0
+brief: OOT Module containing all blocks requiring for a functional LoRa transceiver
+tags: # Tags are arbitrary, but look at CGRAN what other authors are using
+  - SDR
+  - LoRa
+author:
+  - Tapparel Joachim <joachim.tapparel@epfl.ch>
+copyright_owner:
+  - Tapparel Joachim
+license: GPL-3.0-or-later
+gr_supported_version:
+  - 3.10
+repo: https://github.com/tapparelj/gr-lora_sdr
+website: https://github.com/tapparelj/gr-lora_sdr
+#icon: # Put a URL to a square image here that will be used as an icon
+description: |-
+  This is the fully-functional GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver with all the necessary receiver components to operate correctly even at very low SNRs. The transceiver is available as a module for GNU Radio 3.10. This work has been conducted at the Telecommunication Circuits Laboratory, EPFL.
+file_format: 1

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,4 +10,4 @@ install(
           tx_rx_hier_functionality_check.grc
           tx_rx_simulation.grc
           tx_rx_usrp.grc
-    DESTINATION ${GR_PKG_DATA_DIR}/examples)
+    DESTINATION share/gnuradio/examples/lora_sdr)


### PR DESCRIPTION
The MANIFEST and examples changes are for compatibility with the (in development) GRC-Qt examples browser and OOT module browser. As of now, some things still rely on the old `MANIFEST.md` (e.g. CGRAN), so that has been left untouched.

The addition of .gitattributes makes checkouts of the repository on Windows have Unix-style line endings for the C++ files, which ensures that the check for the header hash for building the Python bindings is the same on Windows.

Somewhat related, I'm also in the process of building [a repository for conda recipes of GNU Radio OOT modules](https://github.com/radioconda/gnuradio-oot-forge), to replace me having to build packages from a bunch of forks for inclusion in radioconda. This will let me update packages much more quickly when the upstream repository has changes. Right now, I'm pointing the gr-lora_sdr recipe to my fork in order to have the changes in this PR, but once merged I can switch it to the upstream here and then automatically build packages whenever you update.