### PR TITLE
Refactor m_sto_frac bounds checking logic

### DIFF
--- a/lib/frame_sync_impl.cc
+++ b/lib/frame_sync_impl.cc
@@ -684,10 +684,14 @@ namespace gr
 
                     // update sto_frac to its value at the beginning of the net id
                     m_sto_frac += sfo_hat * m_preamb_len;
-                    // ensure that m_sto_frac is in [-0.5,0.5]
-                    if (abs(m_sto_frac) > 0.5)
+                    // ensure that m_sto_frac is in [-0.5,0.5], repeat until m_sto_frac is in bounds.
+                    while (m_sto_frac > 0.5)
                     {
-                        m_sto_frac = m_sto_frac + (m_sto_frac > 0 ? -1 : 1);
+                        m_sto_frac -= 1.0;
+                    }
+                    while (m_sto_frac < -0.5)
+                    {
+                        m_sto_frac += 1.0;
                     }
                     // decim net id according to new sto_frac and sto int
                     std::vector<gr_complex> net_ids_samp_dec;


### PR DESCRIPTION
During our experiments utilizing gr-lora for acoustic LoRa testing we found that the frame_sync block would crash when the center frequency was not a significant multiple of the bandwidth.

The crash was caused by a segfault in `net_ids_samp_dec` where `start_off` would underflow to `INT_MIN`. The underflow was caused by the original upstream logic not able to successfully bound `m_sto_frac` to [-0.5,0.5] if a large `sto_hat` is present. This issue does not occur in typical RF LoRa conditions because the ratio between the center frequency and the bandwidth is significant, however this is not the case for acoustic conditions where a small ratio produces a large `sto_hat`.

The updated logic corrects this by replacing the singular decrement/increment per cycle that fails when `sto_hat` is large with multiple iterations that bound `m_sto_frac` in a single cycle.

This does not alter its behavior under RF conditions where `sto_hat` is typically small.