### PR TITLE
Add downlink rx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Thanks to Ryan Volz this OOT module can also directly be installed as a Conda pa
 		[grc]
 		local_blocks_path=path_to_the_downloaded_folder/gr-lora_sdr/grc
 ## Changelog
+- Add downlink rx support.
 - Add option to ignore sync words checks and print the received values
 - Add optional print of received payload as hex values
 - Added tagged stream input support (for frame definition of frame length)

--- a/lib/crc_verif_impl.cc
+++ b/lib/crc_verif_impl.cc
@@ -96,6 +96,8 @@ namespace gr
                 // std::cout<<m_payload_len<<" "<<nitem_to_process<<std::endl;
                 // std::cout<<"\ncrc_crc "<<tags[0].offset<<" - crc: "<<(int)m_crc_presence<<" - pay_len: "<<(int)m_payload_len<<"\n";
                 
+                is_uplink = pmt::to_bool(pmt::dict_ref(tags[0].value, pmt::string_to_symbol("is_uplink"), err));
+                // is_uplink = pmt::to_bool(pmt::dict_ref(tags[0].value, pmt::intern("is_uplink"), err));
                 
             }
             //append received bytes to buffer
@@ -155,6 +157,11 @@ namespace gr
                     }
                     if (print_rx_msg != NONE)
                     {
+                        if (is_uplink)
+                            std::cout << ">----Uplink frame----<" << std::endl;
+                        else
+                            std::cout << ">---Downlink frame---<" << std::endl;
+
                         if(print_rx_msg == ASCII)
                             std::cout << "rx msg: " << message_str << std::endl;                        
                         else if(print_rx_msg == HEX){

--- a/lib/crc_verif_impl.h
+++ b/lib/crc_verif_impl.h
@@ -21,6 +21,7 @@ namespace gr {
         int print_rx_msg;  ///< print received message in terminal. 0: no print, 1: ASCII, 2: HEX
         bool output_crc_check; ///< output the result of the payload CRC check
         tag_t current_tag; ///< the most recent tag for the packet we are currently processing
+        bool is_uplink;    ///< Indicate whether the current rx is uplink/downlink
         
 
         uint32_t cnt=0;///< count the number of frame

--- a/lib/fft_demod_impl.cc
+++ b/lib/fft_demod_impl.cc
@@ -84,7 +84,7 @@ namespace gr {
             kiss_fft_cpx *cx_out = new kiss_fft_cpx[m_samples_per_symbol];
 
             // Multiply with ideal downchirp
-            volk_32fc_x2_multiply_32fc(&m_dechirped[0], samples, &m_downchirp[0], m_samples_per_symbol);
+            volk_32fc_x2_multiply_32fc(&m_dechirped[0], samples, &(*m_ref_chirp_ptr)[0], m_samples_per_symbol);
             for (uint32_t i = 0; i < m_samples_per_symbol; i++) {
                 cx_in[i].r = m_dechirped[i].real();
                 cx_in[i].i = m_dechirped[i].imag();
@@ -214,7 +214,12 @@ namespace gr {
                     double max_X1(0), max_X0(0); // X1 = set of symbols where i-th bit is '1'
                     for (uint32_t n = 0; n < m_samples_per_symbol; n++) {  // for all symbols n : 0 --> 2^sf
                         // LoRa: shift by -1 and use reduce rate if first block (header)
-                        uint32_t s = mod(n - 1, (1 << m_sf)) / ((is_header||m_ldro )? 4 : 1);
+                        uint32_t s;
+                        if (is_uplink)
+                            s = mod(n - 1, (1 << m_sf)) / ((is_header||m_ldro )? 4 : 1);
+                        else
+                            s = mod(m_samples_per_symbol - n - 1, (1 << m_sf)) / ((is_header||m_ldro )? 4 : 1);
+
                         s = (s ^ (s >> 1u));  // Gray encoding formula               // Gray demap before (in this block)
                         if (s & (1u << i)) {  // if i-th bit of symbol n is '1'
                             if (LLs[n] > max_X1) max_X1 = LLs[n];
@@ -229,7 +234,12 @@ namespace gr {
                 for (uint32_t i = 0; i < m_sf; i++) {
                     double sum_X1(0), sum_X0(0); // X1 = set of symbols where i-th bit is '1'
                     for (uint32_t n = 0; n < m_samples_per_symbol; n++) {  // for all symbols n : 0 --> 2^sf
-                        uint32_t s = mod(n - 1, (1 << m_sf)) / ((is_header||m_ldro)? 4 : 1);
+                        uint32_t s;
+                        if (is_uplink)
+                            s = mod(n - 1, (1 << m_sf)) / ((is_header||m_ldro )? 4 : 1);
+                        else
+                            s = mod(m_samples_per_symbol - n - 1, (1 << m_sf)) / ((is_header||m_ldro )? 4 : 1);
+
                         s = (s ^ (s >> 1u));  // Gray demap
                         if (s & (1u << i)) sum_X1 += LLs[n]; // Likelihood
                         else sum_X0 += LLs[n];
@@ -272,21 +282,33 @@ namespace gr {
             if (tags.size()) 
             {
                 pmt::pmt_t err = pmt::string_to_symbol("error");
+                
                 is_header = pmt::to_bool(pmt::dict_ref(tags[0].value, pmt::string_to_symbol("is_header"), err));
                 if (is_header) // new frame beginning
                 {
+                    is_uplink = pmt::to_bool(pmt::dict_ref(tags[0].value, pmt::string_to_symbol("is_uplink"), err));
+    
                     int cfo_int = pmt::to_long(pmt::dict_ref(tags[0].value, pmt::string_to_symbol("cfo_int"), err));
                     float cfo_frac = pmt::to_float(pmt::dict_ref(tags[0].value, pmt::string_to_symbol("cfo_frac"), err));
                     int sf = pmt::to_double(pmt::dict_ref(tags[0].value, pmt::string_to_symbol("sf"), err));
                     if(sf != m_sf)
                         set_sf(sf);
-                     //create downchirp taking CFO_int into account
-                    build_upchirp(&m_upchirp[0], mod(cfo_int, m_samples_per_symbol), m_sf);
-                    volk_32fc_conjugate_32fc(&m_downchirp[0], &m_upchirp[0], m_samples_per_symbol);
-                    // adapt the downchirp to the cfo_frac of the frame
+
+                    //create downchirp taking CFO_int into account
+                    if (is_uplink){
+                        build_upchirp(&m_upchirp[0], mod(cfo_int, m_samples_per_symbol), m_sf);
+                        volk_32fc_conjugate_32fc(&m_downchirp[0], &m_upchirp[0], m_samples_per_symbol);
+                        m_ref_chirp_ptr = &m_downchirp;
+                    }
+                    else{
+                        build_upchirp(&m_upchirp[0], mod(-cfo_int, m_samples_per_symbol), m_sf);
+                        m_ref_chirp_ptr = &m_upchirp;
+                    }
+
+                    // adapt the reference chirp to the cfo_frac of the frame
                     for (uint32_t n = 0; n < m_samples_per_symbol; n++)
-                    {
-                        m_downchirp[n] = m_downchirp[n] * gr_expj(-2 * M_PI * cfo_frac / m_samples_per_symbol * n);
+                    {   
+                        (*m_ref_chirp_ptr)[n] = (*m_ref_chirp_ptr)[n] * gr_expj(-2 * M_PI * cfo_frac / m_samples_per_symbol * n);
                     }
                     output.clear();
                 } 
@@ -309,8 +331,14 @@ namespace gr {
                 if (m_soft_decoding) {
                     LLRs_block.push_back(get_LLRs(in));  // Store 'sf' LLRs
                 } else {                                 // Hard decoding
+                    uint16_t symb = get_symbol_val(in);
+
+                    // adjust symbol if downlink
+                    if (!is_uplink)
+                        symb = m_samples_per_symbol - symb;
+                    
                     // shift by -1 and use reduce rate if first block (header)
-                    output.push_back(mod(get_symbol_val(in) - 1, (1 << m_sf)) / ((is_header||m_ldro) ? 4 : 1));
+                    output.push_back(mod(symb - 1, (1 << m_sf)) / ((is_header||m_ldro) ? 4 : 1));
                 }
 
                 if (output.size() == block_size || LLRs_block.size() == block_size) {
@@ -329,6 +357,7 @@ namespace gr {
                     to_output = 0;
                 }
                 consume_each(m_samples_per_symbol);
+
                 m_symb_cnt += 1;
                 if(m_symb_cnt == m_symb_numb){
                 // std::cout<<"fft_demod_impl.cc end of frame\n";

--- a/lib/fft_demod_impl.h
+++ b/lib/fft_demod_impl.h
@@ -41,11 +41,13 @@ namespace gr {
       std::vector<gr_complex> m_downchirp; ///< Reference downchirp
       std::vector<gr_complex> m_dechirped; ///< Dechirped symbol
       std::vector<gr_complex> m_fft;       ///< Result of the FFT
+      std::vector<gr_complex> *m_ref_chirp_ptr;  ///< Pointer to reference chirp used for in demodulation: points to m_downchirp/m_upchirp
 
       std::vector<uint16_t> output;   ///< Stores the value to be outputted once a full bloc has been received
       std::vector< std::vector<LLR> > LLRs_block; ///< Stores the LLRs to be outputted once a full bloc has been received
       bool is_header;                  ///< Indicate that the first block hasn't been fully received
       uint8_t block_size;             ///< The number of lora symbol in one block
+      bool is_uplink;                  ///< Indicate whether the current rx is uplink/downlink
      
       #ifdef GRLORA_MEASUREMENTS
       std::ofstream energy_file;

--- a/lib/frame_sync_impl.cc
+++ b/lib/frame_sync_impl.cc
@@ -63,21 +63,27 @@ namespace gr
             additional_symbol_samp.resize(2 * m_samples_per_symbol);
             m_upchirp.resize(m_number_of_bins);
             m_downchirp.resize(m_number_of_bins);
-            preamble_upchirps.resize(m_preamb_len * m_number_of_bins);
-            preamble_raw_up.resize((m_preamb_len + 3) * m_samples_per_symbol);
+            preamble_chirps.resize(m_preamb_len * m_number_of_bins);
+            preamble_up_raw_os.resize((m_preamb_len + 3) * m_samples_per_symbol);
+            preamble_down_raw_os.resize((m_preamb_len + 3) * m_samples_per_symbol);
             CFO_frac_correc.resize(m_number_of_bins);
             CFO_SFO_frac_correc.resize(m_number_of_bins);
             symb_corr.resize(m_number_of_bins);
             in_down.resize(m_number_of_bins);
-            preamble_raw.resize(m_preamb_len * m_number_of_bins);
+            preamble_up_raw.resize(m_preamb_len * m_number_of_bins);
+            preamble_down_raw.resize(m_preamb_len * m_number_of_bins);
             net_id_samp.resize(m_samples_per_symbol * 2.5); // we should be able to move up to one quarter of symbol in each direction
 
             build_ref_chirps(&m_upchirp[0], &m_downchirp[0], m_sf);
 
-            bin_idx = 0;
+            bin_idx_up = 0;
+            bin_idx_down = 0;
             symbol_cnt = 1;
+            upchirp_cnt= 1;
+            downchirp_cnt = 1;
             k_hat = 0;
             preamb_up_vals.resize(m_n_up_req, 0);
+            preamb_down_vals.resize(m_n_up_req, 0);
             frame_cnt = 0;
             m_symb_numb = 0;
 
@@ -137,7 +143,7 @@ namespace gr
             std::vector<gr_complex> downchirp_aug(up_symb_to_use * m_number_of_bins);
             for (int i = 0; i < up_symb_to_use; i++)
             {
-                memcpy(&downchirp_aug[i * m_number_of_bins], &m_downchirp[0], m_number_of_bins * sizeof(gr_complex));
+                memcpy(&downchirp_aug[i * m_number_of_bins], &(*m_ref_chirp_ptr)[0], m_number_of_bins * sizeof(gr_complex));
             }
 
             // Dechirping
@@ -187,7 +193,7 @@ namespace gr
                 CFO_frac_correc_aug[n] = gr_expj(-2 * M_PI * (cfo_frac) / m_number_of_bins * n);
             }
 
-            volk_32fc_x2_multiply_32fc(&preamble_upchirps[0], samples, &CFO_frac_correc_aug[0], up_symb_to_use * m_number_of_bins);
+            volk_32fc_x2_multiply_32fc(&preamble_chirps[0], samples, &CFO_frac_correc_aug[0], up_symb_to_use * m_number_of_bins);
 
             return cfo_frac;
         }
@@ -211,7 +217,7 @@ namespace gr
             for (int i = 0; i < up_symb_to_use; i++)
             {
                 // Dechirping
-                volk_32fc_x2_multiply_32fc(&dechirped[0], &samples[m_number_of_bins * i], &m_downchirp[0], m_number_of_bins);
+                volk_32fc_x2_multiply_32fc(&dechirped[0], &samples[m_number_of_bins * i], &(*m_ref_chirp_ptr)[0], m_number_of_bins);
                 // prepare FFT
                 for (uint32_t j = 0; j < m_number_of_bins; j++)
                 {
@@ -247,7 +253,7 @@ namespace gr
             {
                 CFO_frac_correc_aug[n] = gr_expj(-2 * M_PI * cfo_frac / m_number_of_bins * n);
             }
-            volk_32fc_x2_multiply_32fc(&preamble_upchirps[0], samples, &CFO_frac_correc_aug[0], up_symb_to_use * m_number_of_bins);
+            volk_32fc_x2_multiply_32fc(&preamble_chirps[0], samples, &CFO_frac_correc_aug[0], up_symb_to_use * m_number_of_bins);
             return cfo_frac;
         }
 
@@ -271,7 +277,7 @@ namespace gr
             for (int i = 0; i < up_symb_to_use; i++)
             {
                 // Dechirping
-                volk_32fc_x2_multiply_32fc(&dechirped[0], &preamble_upchirps[m_number_of_bins * i], &m_downchirp[0], m_number_of_bins);
+                volk_32fc_x2_multiply_32fc(&dechirped[0], &preamble_chirps[m_number_of_bins * i], &(*m_ref_chirp_ptr)[0], m_number_of_bins);
 
                 // prepare FFT
                 for (uint32_t j = 0; j < 2 * m_number_of_bins; j++)
@@ -363,8 +369,8 @@ namespace gr
 
             kiss_fft_cfg cfg = kiss_fft_alloc(m_number_of_bins, 0, 0, 0);
 
-            // Multiply with ideal downchirp
-            volk_32fc_x2_multiply_32fc(&dechirped[0], samples, &m_downchirp[0], m_number_of_bins);
+            // Multiply with ideal downchirp/upchirp
+            volk_32fc_x2_multiply_32fc(&dechirped[0], samples, &(*m_ref_chirp_ptr)[0], m_number_of_bins);
 
             for (uint32_t i = 0; i < m_number_of_bins; i++)
             {
@@ -423,6 +429,7 @@ namespace gr
                 frame_info = pmt::dict_delete(frame_info, pmt::intern("ldro_mode"));
 
                 frame_info = pmt::dict_add(frame_info, pmt::intern("ldro"), pmt::from_bool(m_ldro));
+                
                 add_item_tag(0, nitems_written(0), pmt::string_to_symbol("frame_info"), frame_info);
             }
         }
@@ -435,13 +442,15 @@ namespace gr
             additional_symbol_samp.resize(2 * m_samples_per_symbol);
             m_upchirp.resize(m_number_of_bins);
             m_downchirp.resize(m_number_of_bins);
-            preamble_upchirps.resize(m_preamb_len * m_number_of_bins);
-            preamble_raw_up.resize((m_preamb_len + 3) * m_samples_per_symbol);
+            preamble_chirps.resize(m_preamb_len * m_number_of_bins);
+            preamble_up_raw_os.resize((m_preamb_len + 3) * m_samples_per_symbol);
+            preamble_down_raw_os.resize((m_preamb_len + 3) * m_samples_per_symbol);
             CFO_frac_correc.resize(m_number_of_bins);
             CFO_SFO_frac_correc.resize(m_number_of_bins);
             symb_corr.resize(m_number_of_bins);
             in_down.resize(m_number_of_bins);
-            preamble_raw.resize(m_preamb_len * m_number_of_bins);
+            preamble_up_raw.resize(m_preamb_len * m_number_of_bins);
+            preamble_down_raw.resize(m_preamb_len * m_number_of_bins);
             net_id_samp.resize(m_samples_per_symbol * 2.5); // we should be able to move up to one quarter of symbol in each direction
             build_ref_chirps(&m_upchirp[0], &m_downchirp[0], m_sf);
 
@@ -504,38 +513,90 @@ namespace gr
             {
             case DETECT:
             {
+                // uplink detection
                 bin_idx_new = get_symbol_val(&in_down[0], &m_downchirp[0]);
 
-                if (abs(mod(abs(bin_idx_new - bin_idx) + 1, m_number_of_bins) - 1) <= 1 && bin_idx_new != -1) // look for consecutive reference upchirps(with a margin of ±1)
+                if (abs(mod(abs(bin_idx_new - bin_idx_up) + 1, m_number_of_bins) - 1) <= 1 && bin_idx_new != -1) // look for consecutive reference upchirps(with a margin of ±1)
                 {
-                    if (symbol_cnt == 1 && bin_idx != -1)
-                        preamb_up_vals[0] = bin_idx;
+                    if (upchirp_cnt == 1 && bin_idx_up != -1)
+                        preamb_up_vals[0] = bin_idx_up;
 
-                    preamb_up_vals[symbol_cnt] = bin_idx_new;
-                    memcpy(&preamble_raw[m_number_of_bins * symbol_cnt], &in_down[0], m_number_of_bins * sizeof(gr_complex));
-                    memcpy(&preamble_raw_up[m_samples_per_symbol * symbol_cnt], &in[(int)(m_os_factor / 2)], m_samples_per_symbol * sizeof(gr_complex));
+                    preamb_up_vals[upchirp_cnt] = bin_idx_new;
+                    memcpy(&preamble_up_raw[m_number_of_bins * upchirp_cnt], &in_down[0], m_number_of_bins * sizeof(gr_complex));
+                    memcpy(&preamble_up_raw_os[m_samples_per_symbol * upchirp_cnt], &in[(int)(m_os_factor / 2)], m_samples_per_symbol * sizeof(gr_complex));
 
-                    symbol_cnt++;
+                    upchirp_cnt++;
                 }
                 else
                 {
-                    memcpy(&preamble_raw[0], &in_down[0], m_number_of_bins * sizeof(gr_complex));
-                    memcpy(&preamble_raw_up[0], &in[(int)(m_os_factor / 2)], m_samples_per_symbol * sizeof(gr_complex));
+                    memcpy(&preamble_up_raw[0], &in_down[0], m_number_of_bins * sizeof(gr_complex));
+                    memcpy(&preamble_up_raw_os[0], &in[(int)(m_os_factor / 2)], m_samples_per_symbol * sizeof(gr_complex));
 
-                    symbol_cnt = 1;
+                    upchirp_cnt = 1;
                 }
-                bin_idx = bin_idx_new;
-                if (symbol_cnt == (int)(m_n_up_req))
+                bin_idx_up = bin_idx_new;
+
+                // downchirp detection
+                bin_idx_new = get_symbol_val(&in_down[0], &m_upchirp[0]);
+
+                if (abs(mod(abs(bin_idx_new - bin_idx_down) + 1, m_number_of_bins) - 1) <= 1 && bin_idx_new != -1) // look for consecutive reference upchirps(with a margin of ±1)
                 {
+                    if (downchirp_cnt == 1 && bin_idx_down != -1)
+                        preamb_down_vals[0] = bin_idx_down;
+
+                    preamb_down_vals[downchirp_cnt] = bin_idx_new;
+                    memcpy(&preamble_down_raw[m_number_of_bins * downchirp_cnt], &in_down[0], m_number_of_bins * sizeof(gr_complex));
+                    memcpy(&preamble_down_raw_os[m_samples_per_symbol * downchirp_cnt], &in[(int)(m_os_factor / 2)], m_samples_per_symbol * sizeof(gr_complex));
+
+                    downchirp_cnt++;
+                }
+                else
+                {
+                    memcpy(&preamble_down_raw[0], &in_down[0], m_number_of_bins * sizeof(gr_complex));
+                    memcpy(&preamble_down_raw_os[0], &in[(int)(m_os_factor / 2)], m_samples_per_symbol * sizeof(gr_complex));
+
+                    downchirp_cnt = 1;
+                }
+                bin_idx_down = bin_idx_new;
+
+                
+                if (upchirp_cnt == (int)(m_n_up_req))
+                {
+                    // uplink preamble detected 
                     additional_upchirps = 0;
                     m_state = SYNC;
+                    upchirp_cnt = 0;
                     symbol_cnt = 0;
                     cfo_frac_sto_frac_est = false;
+                    is_uplink = true;
+                    preamble_raw_ptr = &preamble_up_raw;
+                    preamble_raw_os_ptr = &preamble_up_raw_os;
+                    m_ref_chirp_ptr = &m_downchirp;
+                    m_ref_chirp_conj_ptr = &m_upchirp;
                     k_hat = most_frequent(&preamb_up_vals[0], preamb_up_vals.size());
                     memcpy(&net_id_samp[0], &in[int(0.75 * m_samples_per_symbol - k_hat * m_os_factor)], sizeof(gr_complex) * 0.25 * m_samples_per_symbol);
 
                     // perform the coarse synchronization
                     items_to_consume = m_os_factor * ((int)(m_number_of_bins - k_hat));
+                }
+                else if (downchirp_cnt == (int)(m_n_up_req))
+                {
+                    // downlink preamble detected 
+                    additional_upchirps = 0;
+                    m_state = SYNC;
+                    downchirp_cnt = 0;
+                    symbol_cnt = 0;
+                    cfo_frac_sto_frac_est = false;
+                    is_uplink = false;
+                    preamble_raw_ptr = &preamble_down_raw;
+                    preamble_raw_os_ptr = &preamble_down_raw_os;
+                    m_ref_chirp_ptr = &m_upchirp;
+                    m_ref_chirp_conj_ptr = &m_downchirp;
+                    k_hat = most_frequent(&preamb_down_vals[0], preamb_down_vals.size());
+                    memcpy(&net_id_samp[0], &in[int(0.75 * m_samples_per_symbol - (m_number_of_bins - k_hat) * m_os_factor)], sizeof(gr_complex) * 0.25 * m_samples_per_symbol);
+
+                    // perform the coarse synchronization
+                    items_to_consume = m_os_factor * ((int)(k_hat));
                 }
                 else
                     items_to_consume = m_samples_per_symbol;
@@ -547,7 +608,11 @@ namespace gr
                 items_to_output = 0;
                 if (!cfo_frac_sto_frac_est)
                 {
-                    m_cfo_frac = estimate_CFO_frac_Bernier(&preamble_raw[m_number_of_bins - k_hat]);
+                    if (is_uplink)
+                        m_cfo_frac = estimate_CFO_frac_Bernier(&(*preamble_raw_ptr)[m_number_of_bins - k_hat]);
+                    else
+                        m_cfo_frac = estimate_CFO_frac_Bernier(&(*preamble_raw_ptr)[k_hat]);
+
                     m_sto_frac = estimate_STO_frac();
                     // create correction vector
                     for (uint32_t n = 0; n < m_number_of_bins; n++)
@@ -560,22 +625,33 @@ namespace gr
                 // apply cfo correction
                 volk_32fc_x2_multiply_32fc(&symb_corr[0], &in_down[0], &CFO_frac_correc[0], m_number_of_bins);
 
-                bin_idx = get_symbol_val(&symb_corr[0], &m_downchirp[0]);
+                bin_idx_new = get_symbol_val(&symb_corr[0], &(*m_ref_chirp_ptr)[0]);
+                if (!is_uplink)
+                    bin_idx_new = mod(m_number_of_bins - bin_idx_new, m_number_of_bins);
+
                 switch (symbol_cnt)
                 {
                 case NET_ID1:
                 {
-                    if (bin_idx == 0 || bin_idx == 1 || (uint32_t)bin_idx == m_number_of_bins - 1)
+                    if (bin_idx_new == 0 || bin_idx_new == 1 || (uint32_t)bin_idx_new == m_number_of_bins - 1)
                     { // look for additional upchirps. Won't work if network identifier 1 equals 2^sf-1, 0 or 1!
                         memcpy(&net_id_samp[0], &in[(int)0.75 * m_samples_per_symbol], sizeof(gr_complex) * 0.25 * m_samples_per_symbol);
                         if (additional_upchirps >= 3)
                         {
-                            std::rotate(preamble_raw_up.begin(), preamble_raw_up.begin() + m_samples_per_symbol, preamble_raw_up.end());
-                            memcpy(&preamble_raw_up[m_samples_per_symbol * (m_n_up_req + 3)], &in[(int)(m_os_factor / 2) + k_hat * m_os_factor], m_samples_per_symbol * sizeof(gr_complex));
+                            std::rotate((*preamble_raw_os_ptr).begin(), (*preamble_raw_os_ptr).begin() + m_samples_per_symbol, (*preamble_raw_os_ptr).end());
+                            
+                            if (is_uplink)
+                                memcpy(&(*preamble_raw_os_ptr)[m_samples_per_symbol * (m_n_up_req + 3)], &in[(int)(m_os_factor / 2) + k_hat * m_os_factor], m_samples_per_symbol * sizeof(gr_complex));
+                            else
+                                memcpy(&(*preamble_raw_os_ptr)[m_samples_per_symbol * (m_n_up_req + 3)], &in[(int)(m_os_factor / 2) + (m_number_of_bins - k_hat) * m_os_factor], m_samples_per_symbol * sizeof(gr_complex));
                         }
                         else
                         {
-                            memcpy(&preamble_raw_up[m_samples_per_symbol * (m_n_up_req + additional_upchirps)], &in[(int)(m_os_factor / 2) + k_hat * m_os_factor], m_samples_per_symbol * sizeof(gr_complex));
+                            if (is_uplink)
+                                memcpy(&(*preamble_raw_os_ptr)[m_samples_per_symbol * (m_n_up_req + additional_upchirps)], &in[(int)(m_os_factor / 2) + k_hat * m_os_factor], m_samples_per_symbol * sizeof(gr_complex));
+                            else
+                                memcpy(&(*preamble_raw_os_ptr)[m_samples_per_symbol * (m_n_up_req + additional_upchirps)], &in[(int)(m_os_factor / 2) + (m_number_of_bins - k_hat) * m_os_factor], m_samples_per_symbol * sizeof(gr_complex));
+                            
                             additional_upchirps++;
                         }
                     }
@@ -583,8 +659,9 @@ namespace gr
                     { // network identifier 1 correct or off by one
                         symbol_cnt = NET_ID2;
                         memcpy(&net_id_samp[0.25 * m_samples_per_symbol], &in[0], sizeof(gr_complex) * m_samples_per_symbol);
-                        net_ids[0] = bin_idx;
+                        net_ids[0] = bin_idx_new;
                     }
+
                     break;
                 }
                 case NET_ID2:
@@ -592,7 +669,7 @@ namespace gr
 
                     symbol_cnt = DOWNCHIRP1;
                     memcpy(&net_id_samp[1.25 * m_samples_per_symbol], &in[0], sizeof(gr_complex) * (m_number_of_bins + 1) * m_os_factor);
-                    net_ids[1] = bin_idx;
+                    net_ids[1] = bin_idx_new;
 
                     break;
                 }
@@ -604,7 +681,7 @@ namespace gr
                 }
                 case DOWNCHIRP2:
                 {
-                    down_val = get_symbol_val(&symb_corr[0], &m_upchirp[0]);
+                    down_val = get_symbol_val(&symb_corr[0], &(*m_ref_chirp_conj_ptr)[0]);
                     memcpy(&additional_symbol_samp[0], &in[0], sizeof(gr_complex) * m_samples_per_symbol);
                     symbol_cnt = QUARTER_DOWN;
                     break;
@@ -622,7 +699,11 @@ namespace gr
                     }
 
                     // correct STOint and CFOint in the preamble upchirps
-                    std::rotate(preamble_upchirps.begin(), preamble_upchirps.begin() + mod(m_cfo_int, m_number_of_bins), preamble_upchirps.end());
+                    if (is_uplink)
+                        std::rotate(preamble_chirps.begin(), preamble_chirps.begin() + mod(m_cfo_int, m_number_of_bins), preamble_chirps.end());
+                    else
+                        std::rotate(preamble_chirps.begin(), preamble_chirps.begin() + mod(-m_cfo_int, m_number_of_bins), preamble_chirps.end());
+
 
                     std::vector<gr_complex> CFO_int_correc;
                     CFO_int_correc.resize((m_n_up_req + additional_upchirps) * m_number_of_bins);
@@ -631,7 +712,7 @@ namespace gr
                         CFO_int_correc[n] = gr_expj(-2 * M_PI * (m_cfo_int) / m_number_of_bins * n);
                     }
 
-                    volk_32fc_x2_multiply_32fc(&preamble_upchirps[0], &preamble_upchirps[0], &CFO_int_correc[0], up_symb_to_use * m_number_of_bins);
+                    volk_32fc_x2_multiply_32fc(&preamble_chirps[0], &preamble_chirps[0], &CFO_int_correc[0], up_symb_to_use * m_number_of_bins);
 
                     // correct SFO in the preamble upchirps
 
@@ -647,7 +728,7 @@ namespace gr
                         sfo_corr_vect[n] = gr_expj(-2 * M_PI * (pow(mod(n, N), 2) / 2 / N * (m_bw / fs_p * m_bw / fs_p - m_bw / fs * m_bw / fs) + (std::floor((float)n / N) * (m_bw / fs_p * m_bw / fs_p - m_bw / fs_p) + m_bw / 2 * (1 / fs - 1 / fs_p)) * mod(n, N)));
                     }
 
-                    volk_32fc_x2_multiply_32fc(&preamble_upchirps[0], &preamble_upchirps[0], &sfo_corr_vect[0], up_symb_to_use * m_number_of_bins);
+                    volk_32fc_x2_multiply_32fc(&preamble_chirps[0], &preamble_chirps[0], &sfo_corr_vect[0], up_symb_to_use * m_number_of_bins);
 
                     float tmp_sto_frac = estimate_STO_frac(); // better estimation of sto_frac in the beginning of the upchirps
                     float diff_sto_frac = m_sto_frac - tmp_sto_frac;
@@ -662,26 +743,33 @@ namespace gr
                     // apply sto correction
                     for (uint32_t i = 0; i < (m_n_up_req + additional_upchirps) * m_number_of_bins; i++)
                     {
-                        corr_preamb[i] = preamble_raw_up[m_os_factor * (m_number_of_bins - k_hat + i) - int(my_roundf(m_os_factor * m_sto_frac))];
+                        if (is_uplink)
+                            corr_preamb[i] = (*preamble_raw_os_ptr)[m_os_factor * (m_number_of_bins - k_hat + i) - int(my_roundf(m_os_factor * m_sto_frac))];
+                        else
+                            corr_preamb[i] = (*preamble_raw_os_ptr)[m_os_factor * (k_hat + i) - int(my_roundf(m_os_factor * m_sto_frac))];
                     }
-                    std::rotate(corr_preamb.begin(), corr_preamb.begin() + mod(m_cfo_int, m_number_of_bins), corr_preamb.end());
+                    if (is_uplink)
+                        std::rotate(corr_preamb.begin(), corr_preamb.begin() + mod(m_cfo_int, m_number_of_bins), corr_preamb.end());
+                    else
+                        std::rotate(corr_preamb.begin(), corr_preamb.begin() + mod(-m_cfo_int, m_number_of_bins), corr_preamb.end());
+
                     // apply cfo correction
                     volk_32fc_x2_multiply_32fc(&corr_preamb[0], &corr_preamb[0], &CFO_int_correc[0], (m_n_up_req + additional_upchirps) * m_number_of_bins);
                     for (int i = 0; i < (m_n_up_req + additional_upchirps); i++)
                     {
                         volk_32fc_x2_multiply_32fc(&corr_preamb[m_number_of_bins * i], &corr_preamb[m_number_of_bins * i], &CFO_frac_correc[0], m_number_of_bins);
                     }
-
+                    
                     // //apply sfo correction
                     volk_32fc_x2_multiply_32fc(&corr_preamb[0], &corr_preamb[0], &sfo_corr_vect[0], (m_n_up_req + additional_upchirps) * m_number_of_bins);
-
+                    
                     float snr_est = 0;
                     for (int i = 0; i < up_symb_to_use; i++)
                     {
-                        snr_est += determine_snr(&corr_preamb[i * m_number_of_bins]);
+                       snr_est += determine_snr(&corr_preamb[i * m_number_of_bins]);
                     }
                     snr_est /= up_symb_to_use;
-
+                    
                     // update sto_frac to its value at the beginning of the net id
                     m_sto_frac += sfo_hat * m_preamb_len;
                     // ensure that m_sto_frac is in [-0.5,0.5]
@@ -689,11 +777,17 @@ namespace gr
                     {
                         m_sto_frac = m_sto_frac + (m_sto_frac > 0 ? -1 : 1);
                     }
+
                     // decim net id according to new sto_frac and sto int
                     std::vector<gr_complex> net_ids_samp_dec;
                     net_ids_samp_dec.resize(2 * m_number_of_bins, 0);
-                    // start_off gives the offset in the net_id_samp vector required to be aligned in time (CFOint is equivalent to STOint since upchirp_val was forced to 0)
-                    int start_off = (int)m_os_factor / 2 - (my_roundf(m_sto_frac * m_os_factor)) + m_os_factor * (.25 * m_number_of_bins + m_cfo_int);
+                    // start_off gives the offset in the net_id_samp vector required to be aligned in time (CFOint is equivalent to -STOint for uplink since upchirp_val was forced to 0, and equivalent to STOint for downlink)
+                    int start_off;
+                    if (is_uplink)
+                        start_off = (int)m_os_factor / 2 - (my_roundf(m_sto_frac * m_os_factor)) + m_os_factor * (.25 * m_number_of_bins + m_cfo_int);
+                    else
+                        start_off = (int)m_os_factor / 2 - (my_roundf(m_sto_frac * m_os_factor)) + m_os_factor * (.25 * m_number_of_bins - m_cfo_int);
+
                     for (uint32_t i = 0; i < m_number_of_bins * 2; i++)
                     {
                         net_ids_samp_dec[i] = net_id_samp[start_off + i * m_os_factor];
@@ -704,8 +798,16 @@ namespace gr
                     volk_32fc_x2_multiply_32fc(&net_ids_samp_dec[0], &net_ids_samp_dec[0], &CFO_frac_correc[0], m_number_of_bins);
                     volk_32fc_x2_multiply_32fc(&net_ids_samp_dec[m_number_of_bins], &net_ids_samp_dec[m_number_of_bins], &CFO_frac_correc[0], m_number_of_bins);
 
-                    int netid1 = get_symbol_val(&net_ids_samp_dec[0], &m_downchirp[0]);
-                    int netid2 = get_symbol_val(&net_ids_samp_dec[m_number_of_bins], &m_downchirp[0]);
+                    int netid1 = get_symbol_val(&net_ids_samp_dec[0], &(*m_ref_chirp_ptr)[0]);
+                    int netid2 = get_symbol_val(&net_ids_samp_dec[m_number_of_bins], &(*m_ref_chirp_ptr)[0]);
+
+                    
+                    if (!is_uplink){
+                        // adjust netids symbols for downlink
+                        netid1 = mod(m_number_of_bins - netid1, m_number_of_bins);
+                        netid2 = mod(m_number_of_bins - netid2, m_number_of_bins);
+                    }
+                    
                     one_symbol_off = 0;
 
                     if (m_sync_words[0] == 0) { // match netid1 only if requested
@@ -723,8 +825,12 @@ namespace gr
                         {
                             net_id_off = netid1 - (int32_t)m_sync_words[1];
                             for (int i = m_preamb_len - 2; i < (m_n_up_req + additional_upchirps); i++)
-                            {
-                                if (get_symbol_val(&corr_preamb[i * m_number_of_bins], &m_downchirp[0]) + net_id_off == m_sync_words[0]) // found the first netID
+                            {   
+                                int netid1_tmp = get_symbol_val(&corr_preamb[i * m_number_of_bins], &(*m_ref_chirp_ptr)[0]);
+                                if (!is_uplink)
+                                    netid1_tmp = mod(m_number_of_bins - netid1_tmp, m_number_of_bins);
+
+                                if (netid1_tmp + net_id_off == m_sync_words[0]) // found the first netID
                                 {
                                     one_symbol_off = 1;
                                     if (net_id_off != 0 && abs(net_id_off) > 1)
@@ -734,7 +840,12 @@ namespace gr
                                     items_to_consume = -m_os_factor * net_id_off;
                                     // the first symbol was mistaken for the end of the downchirp. we should correct and output it.
 
-                                    int start_off = (int)m_os_factor / 2 - my_roundf(m_sto_frac * m_os_factor) + m_os_factor * (0.25 * m_number_of_bins + m_cfo_int);
+                                    int start_off;
+                                    if (is_uplink)
+                                        start_off = (int)m_os_factor / 2 - my_roundf(m_sto_frac * m_os_factor) + m_os_factor * (0.25 * m_number_of_bins + m_cfo_int);
+                                    else
+                                        start_off = (int)m_os_factor / 2 - my_roundf(m_sto_frac * m_os_factor) + m_os_factor * (0.25 * m_number_of_bins - m_cfo_int);
+
                                     for (int i = start_off; i < 1.25 * m_samples_per_symbol; i += m_os_factor)
                                     {
 
@@ -803,11 +914,16 @@ namespace gr
                         frame_info = pmt::dict_add(frame_info, pmt::intern("cfo_int"), pmt::mp((long)m_cfo_int));
                         frame_info = pmt::dict_add(frame_info, pmt::intern("cfo_frac"), pmt::mp((float)m_cfo_frac));
                         frame_info = pmt::dict_add(frame_info, pmt::intern("sf"), pmt::mp((long)m_sf));
+                        frame_info = pmt::dict_add(frame_info, pmt::intern("is_uplink"), pmt::from_bool(is_uplink));
 
                         add_item_tag(0, nitems_written(0), pmt::string_to_symbol("frame_info"), frame_info);
 
                         m_received_head = false;
-                        items_to_consume += m_samples_per_symbol / 4 + m_os_factor * m_cfo_int;
+                        if (is_uplink)
+                            items_to_consume += m_samples_per_symbol / 4 + m_os_factor * m_cfo_int;
+                        else
+                            items_to_consume += m_samples_per_symbol / 4 - m_os_factor * m_cfo_int;
+
                         symbol_cnt = one_symbol_off;
                         float snr_est2 = 0;
 
@@ -817,11 +933,16 @@ namespace gr
 
                             for (int i = 0; i < up_symb_to_use; i++)
                             {
-                                snr_est2 += determine_snr(&preamble_upchirps[i * m_number_of_bins]);
+                                snr_est2 += determine_snr(&preamble_chirps[i * m_number_of_bins]);
                             }
                             snr_est2 /= up_symb_to_use;
                             float cfo_log = m_cfo_int + m_cfo_frac;
-                            float sto_log = k_hat - m_cfo_int + m_sto_frac;
+                            float sto_log;
+                            if (is_uplink)
+                                sto_log = k_hat - m_cfo_int + m_sto_frac;
+                            else
+                                sto_log = k_hat + m_cfo_int + m_sto_frac;
+
                             float srn_log = snr_est;
                             float sfo_log = sfo_hat;
 

--- a/lib/frame_sync_impl.h
+++ b/lib/frame_sync_impl.h
@@ -66,8 +66,11 @@ namespace gr
 
       unsigned int frame_cnt;      ///< Number of frame received
       int32_t symbol_cnt;  ///< Number of symbols already received
-      int32_t bin_idx;     ///< value of previous lora symbol
-      int32_t bin_idx_new; ///< value of newly demodulated symbol
+      int32_t upchirp_cnt;  /// < Number of preamble upchirps already received
+      int32_t downchirp_cnt;  /// < Number of preamble downchirps already received (downlink rx)
+      int32_t bin_idx_up;     ///< value of previous lora upchirp symbol
+      int32_t bin_idx_down;     ///< value of previous lora downchirp symbol (downlink rx)
+      int32_t bin_idx_new; ///< value of newly demodulated upchip/downchirp symbol
 
       uint16_t m_preamb_len; ///< Number of consecutive upchirps in preamble
       uint8_t additional_upchirps; ///< indicate the number of additional upchirps found in preamble (in addition to the minimum required to trigger a detection)
@@ -80,16 +83,24 @@ namespace gr
 
       int one_symbol_off; ///< indicate that we are offset by one symbol after the preamble 
       std::vector<gr_complex> additional_symbol_samp;  ///< save the value of the last 1.25 downchirp as it might contain the first payload symbol
-      std::vector<gr_complex> preamble_raw;      ///<vector containing the preamble upchirps without any synchronization
-      std::vector<gr_complex> preamble_raw_up;  ///<vector containing the upsampled preamble upchirps without any synchronization
-      std::vector<gr_complex> downchirp_raw;    ///< vector containing the preamble downchirps without any synchronization
-      std::vector<gr_complex> preamble_upchirps; ///<vector containing the preamble upchirps
+      std::vector<gr_complex> preamble_up_raw;      ///< vector containing the preamble upchirps without any synchronization
+      std::vector<gr_complex> preamble_down_raw;      ///< vector containing the preamble downchirps without any synchronization (for a downlink rx)
+      std::vector<gr_complex> preamble_up_raw_os;  ///< vector containing the oversampled preamble upchirps without any synchronization
+      std::vector<gr_complex> preamble_down_raw_os;  ///< vector containing the oversampled preamble downchirps without any synchronization (for a downlink rx)
+      // std::vector<gr_complex> downchirp_raw;    ///< vector containing the preamble downchirps without any synchronization
+      std::vector<gr_complex> preamble_chirps; ///< vector containing the synchronized preamble upchirps/downchirps
+      std::vector<gr_complex> *preamble_raw_ptr;   ///< pointer to the preamble chirp samples: preamble_up_raw/preamble_down_raw for uplink/downlink
+      std::vector<gr_complex> *preamble_raw_os_ptr;   ///< pointer to the oversampled preamble chirp samples: preamble_up_raw_os/preamble_down_raw_os for uplink/downlink
+      std::vector<gr_complex> *m_ref_chirp_ptr;   ///< pointer to reference chirp: m_downchirp/m_upchirp for uplink/downlink
+      std::vector<gr_complex> *m_ref_chirp_conj_ptr;   ///< pointer to conjugate reference chirp: m_upchirp/m_downchirp for uplink/downlink
       std::vector<gr_complex> net_id_samp;       ///< vector of the oversampled network identifier samples
       std::vector<int> net_ids;                  ///< values of the network identifiers received
 
       int up_symb_to_use;              ///< number of upchirp symbols to use for CFO and STO frac estimation
       int k_hat;                       ///< integer part of CFO+STO
       std::vector<int> preamb_up_vals; ///< value of the preamble upchirps
+      std::vector<int> preamb_down_vals; ///< value of the preamble downchirps (downlink rx)
+      bool is_uplink = true;        ///< Indicate whether the current rx is uplink/downlink
 
       float m_cfo_frac;                            ///< fractional part of CFO
       float m_cfo_frac_bernier;                    ///< fractional part of CFO using Berniers algo

--- a/lib/header_decoder_impl.cc
+++ b/lib/header_decoder_impl.cc
@@ -53,7 +53,7 @@ namespace gr
             ninput_items_required[0] = noutput_items;
         }
 
-        void header_decoder_impl::publish_frame_info(int cr, int pay_len, int crc, uint8_t ldro_mode, int err)
+        void header_decoder_impl::publish_frame_info(int cr, int pay_len, int crc, uint8_t ldro_mode, int err, bool is_uplink)
         {
 
             pmt::pmt_t header_content = pmt::make_dict();
@@ -63,9 +63,12 @@ namespace gr
             header_content = pmt::dict_add(header_content, pmt::intern("crc"), pmt::from_long(crc));
             header_content = pmt::dict_add(header_content, pmt::intern("ldro_mode"), pmt::from_long(ldro_mode));
             header_content = pmt::dict_add(header_content, pmt::intern("err"), pmt::from_long(err));
+            
             message_port_pub(pmt::intern("frame_info"), header_content);
-            if(!err) //don't propagate downstream that a frame was detected
+            if(!err){ //don't propagate downstream that a frame was detected
+                header_content = pmt::dict_add(header_content, pmt::intern("is_uplink"), pmt::from_bool(is_uplink));        // propagate rx direction for downstream blocks
                 add_item_tag(0, nitems_written(0), pmt::string_to_symbol("frame_info"), header_content);
+            }
         }
 
         int header_decoder_impl::general_work(int noutput_items,
@@ -101,6 +104,7 @@ namespace gr
                     // print("ac ishead: "<<is_header);
                     if (is_header)
                     {
+                        is_uplink = pmt::to_bool(pmt::dict_ref(tags[0].value, pmt::string_to_symbol("is_uplink"), pmt::from_bool(false)));
                         pay_cnt = 0;
                     }
                 }
@@ -113,7 +117,7 @@ namespace gr
             {
                 if (m_impl_header)
                 { //implicit header, all parameters should have been provided
-                    publish_frame_info(m_cr, m_payload_len, m_has_crc, m_ldro_mode, 0);
+                    publish_frame_info(m_cr, m_payload_len, m_has_crc, m_ldro_mode, 0, is_uplink);
 
                     for (int i = 0; i < nitem_to_process; i++)
                     {
@@ -169,7 +173,7 @@ namespace gr
 #endif
                         noutput_items = nitem_to_process - header_len;
                     }
-                    publish_frame_info(m_cr, m_payload_len, m_has_crc, m_ldro_mode, head_err);
+                    publish_frame_info(m_cr, m_payload_len, m_has_crc, m_ldro_mode, head_err, is_uplink);
                     // print("pub header info");
                     for (int i = header_len, j = 0; i < nitem_to_process; i++, j++)
                     {

--- a/lib/header_decoder_impl.h
+++ b/lib/header_decoder_impl.h
@@ -25,6 +25,8 @@ namespace gr {
         uint32_t pay_cnt;///< The number of payload nibbles received
         uint32_t nout;///< The number of data nibbles to output
         bool is_header ;///< Indicate that we need to decode the header
+        bool is_uplink;    ///< Indicate whether the current rx is uplink/downlink
+
 
         /**
          *  \brief  Reset the block variables for a new frame.
@@ -33,7 +35,7 @@ namespace gr {
         /**
          *  \brief publish decoding information contained in the header or provided to the block   
          */
-        void publish_frame_info(int cr, int pay_len, int crc, uint8_t ldro, int err);
+        void publish_frame_info(int cr, int pay_len, int crc, uint8_t ldro, int err, bool is_uplink = true);
 
      public:
       header_decoder_impl(bool impl_head, uint8_t cr, uint32_t pay_len, bool has_crc, uint8_t ldro_mode, bool print_header);


### PR DESCRIPTION
Hello @tapparelj,

I have added support for downlink frame reception in parallel to the default uplink. Below is a detailed description of the changes made to the code.
In the `frame_sync` block, uplink and downlink preambles detection are performed in parallel, and the subsequent synchronization is carried out for whichever preamble was detected. An `is_uplink` flag has been added to the `frame_info` tag to notify downstream blocks of the direction of the preamble detected. Few changes have been made to some of the variable names to avoid any confusion:
* the `_up` suffix for _upsampled_ has been changed to `_os` for _oversampled_. 
* `up` is now used for upchirp related variables, and `down` for downchirp related ones. Therefore, the former `preamble_raw_up` is now `preamble_up_raw_os`, and former `preamble_raw` is now `preamble_up_raw`. Similarly, downchirp counterparts have been added as `preamble_dwn_raw_os`,  `preamble_dwn_raw`, `preamb_dwn_vals`. 
* `preamble_upchirps` has been changed to `preamble_chirps` and contains either the synchronized preamble upchirps or downchirps.
* Pointers `preamble_raw_os_ptr`, `preamble_raw_ptr`, `m_ref_chirp_ptr`, and `m_ref_chirp_conj_ptr` are set to the appropriate samples buffers before subsequent synchronization operations.
* I wanted to update the `SYNC` states `DOWNCHIRP1`, `DOWNCHIRP2` and `QUARTER_DOWN` to something reflecting both upchirps and downchirps, but since that sounds like a lot of changes, I leave that to your appreciation.

In the `fft_demod` block, the despreading ideal chirp is now built according to the frame direction indicated by `is_uplink'.

The `publish_frame_info` method of the `header_decoder` block has been updated to propagate the frame direction to downstream blocks with the `frame_info` tag.

The `crc_verif` block now prints the frame direction along with the payload like: 

>\>----Uplink frame----<
>  rx msg: Hello world 01
>  CRC valid!
> 
and
> \>---Downlink frame---<
> rx msg: Hello world 17
> CRC valid!
> 

Finally, I allowed myself to update the README with mention to the downlink support.